### PR TITLE
Use Oracle JDK8, rather than OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
   - 2.10.4
   - 2.11.0-RC3
 jdk:
-  - openjdk8
+  - oraclejdk8
 notifications:
   email:
     - jason.zaugg@typesafe.com


### PR DESCRIPTION
Travis says: "Sorry, but JDK 'openjdk8' is not known."
