### PR TITLE
Fix cross version of genjavadoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ inConfig(JavaDoc)(Defaults.configSettings) ++ Seq(
   ),
   javacOptions in JavaDoc := Seq(),
   artifactName in packageDoc in JavaDoc := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"),
-  libraryDependencies += compilerPlugin("com.typesafe.genjavadoc" % "genjavadoc-plugin_2.10.4" % "0.5"),
+  libraryDependencies += compilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.5" cross CrossVersion.full),
   scalacOptions in Compile <+= target map (t => "-P:genjavadoc:out=" + (t / "java"))
 )
 


### PR DESCRIPTION
I accidentally commited the hard-coded `_2.10.4` recently.
