### PR TITLE
Ensure scala.concurrent.java8._ is packaged

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ scalaModuleOsgiSettings
 
 OsgiKeys.exportPackage := Seq(s"scala.compat.java8.*;version=${version.value}")
 
+OsgiKeys.privatePackage := List("scala.concurrent.java8.*")
+
 libraryDependencies += "junit" % "junit" % "4.11" % "test"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
@@ -96,6 +98,6 @@ initialCommands :=
 """|import scala.concurrent._
    |import ExecutionContext.Implicits.global
    |import java.util.concurrent.{CompletionStage,CompletableFuture}
-   |import scala.concurrent.java8.FutureConverter._
+   |import scala.compat.java8.FutureConverter._
    |""".stripMargin
 


### PR DESCRIPTION
The implementation of `FutureConverters` needs to access
some `private[concurrent]` members in the standard library.
To do so, it places some of its implementation under this package.

However, the OSGi SBT plugin seems to silently remove packages from the
final artifact that aren't either a publicly exported or a declared
private package.

Because of this, the 0.2.0 released JARs did not contain these
classes, and using FutureConverters resulted in a linkage error.

After this commit:

```
% sbt clean publishLocal

% jar tf target/scala-2.11/scala-java8-compat_2.11-0.2.0-SNAPSHOT.jar | grep -v 'scala/compat'
META-INF/MANIFEST.MF
scala-java8-compat.properties
scala/
scala/concurrent/
scala/concurrent/java8/
scala/concurrent/java8/FuturesConvertersImpl$.class
scala/concurrent/java8/FuturesConvertersImpl$CF$$anon$1.class
scala/concurrent/java8/FuturesConvertersImpl$CF.class
scala/concurrent/java8/FuturesConvertersImpl$P.class
scala/concurrent/java8/FuturesConvertersImpl.class
```

As compared with:

```
% curl --silent https://oss.sonatype.org/content/repositories/releases/org/scala-lang/modules/scala-java8-compat_2.11/0.2.0/scala-java8-compat_2.11-0.2.0.jar | tar tf - | grep -v 'scala/compat'
META-INF/MANIFEST.MF
scala-java8-compat.properties
scala/
```

Review by @rkuhn