### PR TITLE
Use Scala's null-aware boxing, rather than Java's.

### DIFF
--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -232,7 +232,7 @@ object CodeGen {
      |
      |@FunctionalInterface
      |public interface JFunction0$suffix extends JFunction0 {
-     |    abstract ${r.prim} apply$suffix();
+     |    ${r.prim} apply$suffix();
      |
      |    default Object apply() { $applyMethodBody }
      |}
@@ -254,7 +254,7 @@ object CodeGen {
      |
      |@FunctionalInterface
      |public interface JFunction1$suffix extends JFunction1 {
-     |    abstract ${r.prim} apply$suffix(${t.prim} v1);
+     |    ${r.prim} apply$suffix(${t.prim} v1);
      |
      |    default Object apply(Object t) { $applyMethodBody }
      |}
@@ -275,7 +275,7 @@ object CodeGen {
      |
      |@FunctionalInterface
      |public interface JFunction2$suffix extends JFunction2 {
-     |    abstract ${r.prim} apply$suffix(${t1.prim} v1, ${t2.prim} v2);
+     |    ${r.prim} apply$suffix(${t1.prim} v1, ${t2.prim} v2);
      |
      |    default Object apply(Object v1, Object v2) { $applyMethodBody }
      |}

--- a/src/test/java/scala/compat/java8/BoxingTest.java
+++ b/src/test/java/scala/compat/java8/BoxingTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package scala.compat.java8;
+
+import org.junit.Test;
+
+public class BoxingTest {
+    @Test
+    public void nullBoxesInterpretedAsZeroF1() {
+        JFunction1 jFunction1 = new JFunction1$mcII$sp() {
+            @Override
+            public int apply$mcII$sp(int v1) {
+                return v1 + 1;
+            }
+        };
+        Integer result = (Integer) jFunction1.apply(null);
+        assert (result.intValue() == 1);
+    }
+
+    @Test
+    public void nullBoxesInterpretedAsZeroF2() {
+        JFunction2 jFunction2 = new JFunction2$mcIII$sp() {
+            @Override
+            public int apply$mcIII$sp(int v1, int v2) {
+                return v1 + v2 + 1;
+            }
+        };
+        Integer result = (Integer) jFunction2.apply(null, null);
+        assert (result.intValue() == 1);
+    }
+}


### PR DESCRIPTION
Scala unboxes null references to a zero value. By contrast, Java throws a
NullPointerException. Our aim in this code is to exactly emulate Scala's
specialization / mixin / erasure phases, so we should use `BoxesRuntime`.

This is a complementary change to:

   https://github.com/retronym/scala/compare/2.11.x...retronym:topic/indylambda-diy-boxing?expand=1