### PR TITLE
Add omitted copyright headers, update to 2015

### DIFF
--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -288,7 +288,7 @@ object CodeGen {
   private val copyright =
     """
     |/*
-    | * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+    | * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
     | */""".stripMargin.trim
 
   private def function0SpecMethods = {

--- a/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveDoubleWrapper.java
+++ b/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveDoubleWrapper.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8.wrappers;
 
 public class IteratorPrimitiveDoubleWrapper implements java.util.PrimitiveIterator.OfDouble {

--- a/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveIntWrapper.java
+++ b/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveIntWrapper.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8.wrappers;
 
 public class IteratorPrimitiveIntWrapper implements java.util.PrimitiveIterator.OfInt {

--- a/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveLongWrapper.java
+++ b/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveLongWrapper.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8.wrappers;
 
 public class IteratorPrimitiveLongWrapper implements java.util.PrimitiveIterator.OfLong {

--- a/src/main/scala/scala/compat/java8/FutureConverters.scala
+++ b/src/main/scala/scala/compat/java8/FutureConverters.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8
 
 import scala.concurrent.java8.FuturesConvertersImpl._

--- a/src/main/scala/scala/compat/java8/OptionConverters.scala
+++ b/src/main/scala/scala/compat/java8/OptionConverters.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8
 
 import language.implicitConversions

--- a/src/main/scala/scala/compat/java8/PrimitiveIteratorConversions.scala
+++ b/src/main/scala/scala/compat/java8/PrimitiveIteratorConversions.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8
 
 import language.implicitConversions
@@ -104,5 +107,3 @@ object PrimitiveIteratorConverters {
     def asPrimitive[That](implicit specOp: SpecializerOfIterators[A, That]): That = specOp.fromScala(underlying)
   }
 }
-
-

--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.concurrent.java8
 
 // Located in this package to access private[concurrent] members

--- a/src/test/java/scala/compat/java8/BoxingTest.java
+++ b/src/test/java/scala/compat/java8/BoxingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
  */
 package scala.compat.java8;
 

--- a/src/test/java/scala/compat/java8/FutureConvertersTest.java
+++ b/src/test/java/scala/compat/java8/FutureConvertersTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8;
 
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/scala/compat/java8/LambdaTest.java
+++ b/src/test/java/scala/compat/java8/LambdaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
  */
 package scala.compat.java8;
 

--- a/src/test/java/scala/compat/java8/OptionConvertersTest.scala
+++ b/src/test/java/scala/compat/java8/OptionConvertersTest.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8
 
 import org.junit.Test

--- a/src/test/java/scala/compat/java8/SpecializedFactoryTest.java
+++ b/src/test/java/scala/compat/java8/SpecializedFactoryTest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8;
 
 import org.junit.Test;

--- a/src/test/java/scala/compat/java8/SpecializedTest.scala
+++ b/src/test/java/scala/compat/java8/SpecializedTest.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8
 
 import org.junit.Test

--- a/src/test/java/scala/compat/java8/SpecializedTestSupport.java
+++ b/src/test/java/scala/compat/java8/SpecializedTestSupport.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package scala.compat.java8;
 
 import java.util.Arrays;


### PR DESCRIPTION
I used `sbt-header` to to the gruntwork. I am considering adding
this to the standard build definition. In the meantime, here's
how to use it locally.

```
% tail -2 .git/info/exclude
project/local.sbt
/local.sbt

% tail local.sbt project/local.sbt
==> local.sbt <==
import de.heikoseeberger.sbtheader.HeaderPattern

headers := Seq("scala", "java").map(f => (f, (HeaderPattern.cStyleBlockComment, """/*
 * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
 */
"""))).toMap

HeaderPlugin.settingsFor(Test)

==> project/local.sbt <==
addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.0")

%  sbt createHeaders test:createHeaders
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=384m; support was removed in 8.0
[info] Loading global plugins from /Users/jason/.sbt/0.13/plugins
[info] Loading project definition from /Users/jason/code/scala-java8-compat/project/project
[info] Loading project definition from /Users/jason/code/scala-java8-compat/project
[info] Set current project to scala-java8-compat (in build file:/Users/jason/code/scala-java8-compat/)
[info] Headers created for 7 files:
[info]   /Users/jason/code/scala-java8-compat/src/main/scala/scala/compat/java8/FutureConverters.scala
[info]   /Users/jason/code/scala-java8-compat/src/main/scala/scala/compat/java8/OptionConverters.scala
[info]   /Users/jason/code/scala-java8-compat/src/main/scala/scala/compat/java8/PrimitiveIteratorConversions.scala
[info]   /Users/jason/code/scala-java8-compat/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
[info]   /Users/jason/code/scala-java8-compat/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveDoubleWrapper.java
[info]   /Users/jason/code/scala-java8-compat/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveIntWrapper.java
[info]   /Users/jason/code/scala-java8-compat/src/main/java/scala/compat/java8/wrappers/IteratorPrimitiveLongWrapper.java
[success] Total time: 0 s, completed 04/05/2015 1:57:41 PM
[info] Headers created for 7 files:
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/OptionConvertersTest.scala
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/SpecializedTest.scala
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/BoxingTest.java
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/FutureConvertersTest.java
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/LambdaTest.java
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/SpecializedFactoryTest.java
[info]   /Users/jason/code/scala-java8-compat/src/test/java/scala/compat/java8/SpecializedTestSupport.java
[success] Total time: 0 s, completed 04/05/2015 1:57:41 PM
```