### PR TITLE
Make bridge interfaces implement serializable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ OsgiKeys.privatePackage := List("scala.concurrent.java8.*")
 
 libraryDependencies += "junit" % "junit" % "4.11" % "test"
 
+libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.4" % "test"
+
 libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
 
 mimaPreviousVersion := None

--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -40,7 +40,7 @@ object CodeGen {
       |$packaging
       |
       |@FunctionalInterface
-      |public interface JFunction0<R> extends scala.Function0<R> {
+      |public interface JFunction0<R> extends scala.Function0<R>, java.io.Serializable {
       |    default void $initName() {
       |    };
       |""".stripMargin
@@ -51,7 +51,7 @@ object CodeGen {
       |$packaging
       |
       |@FunctionalInterface
-      |public interface JFunction1<T1, R> extends scala.Function1<T1, R> {
+      |public interface JFunction1<T1, R> extends scala.Function1<T1, R>, java.io.Serializable {
       |    default void $initName() {
       |    };
       |
@@ -77,7 +77,7 @@ object CodeGen {
        |$packaging
        |
        |@FunctionalInterface
-       |public interface JFunction$n<$tparams, R> extends scala.Function$n<$tparams, R> {
+       |public interface JFunction$n<$tparams, R> extends scala.Function$n<$tparams, R>, java.io.Serializable {
        |    default void $initName() {
        |    };
        |

--- a/src/test/java/scala/compat/java8/LambdaTest.java
+++ b/src/test/java/scala/compat/java8/LambdaTest.java
@@ -3,11 +3,15 @@
  */
 package scala.compat.java8;
 
+import org.apache.commons.lang3.SerializationUtils;
 import scala.runtime.*;
+
+import static junit.framework.Assert.assertEquals;
 import static scala.compat.java8.JFunction.*;
 import static scala.compat.java8.TestAPI.*;
 
 import org.junit.Test;
+
 
 public class LambdaTest {
     @Test
@@ -93,6 +97,21 @@ public class LambdaTest {
 
         assert(acceptFunction22(func((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22) -> join(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22))).equals("12345678910111213141516171819202122"));
         acceptFunction22Unit(   proc((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22) -> {v1.toUpperCase(); return;}));
+    }
+
+    @Test
+    public void isSerializable() {
+        scala.compat.java8.JFunction0<String> f0 = () -> "foo";
+        assertEquals("foo", SerializationUtils.clone(f0).apply());
+
+        scala.compat.java8.JFunction1<String, String> f1 = (a) -> a.toUpperCase();
+        assertEquals("FOO", SerializationUtils.clone(f1).apply("foo"));
+
+        scala.compat.java8.JFunction2<String, String, String> f2 = (a, b) -> a + b;
+        assertEquals("foobar", SerializationUtils.clone(f2).apply("foo", "bar"));
+
+        scala.compat.java8.JFunction3<String, String, String, String> f3 = (a, b, c) -> a + b + c;
+        assertEquals("foobarbaz", SerializationUtils.clone(f3).apply("foo", "bar", "baz"));
     }
 
     private static scala.concurrent.Future<Integer> futureExample(


### PR DESCRIPTION
I'm trying to use this library to help with some Java8 code written on top of the Spark API.  I'm using a spark library that takes scala Function1s.  Unfortunately, I cannot use the scala-java8-compat library because the bridge interface does not extend Serializable and for a java8 lambda to be serializable the target type has to be serializable: http://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html#serialization