### PR TITLE
Support blocking with: `scalaFuture.toJava.toCompletableFuture`

### DIFF
--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -72,9 +72,11 @@ object FuturesConvertersImpl {
      * WARNING: completing the result of this method will not complete the underlying
      *          Scala Future or Promise (ie, the one that that was passed to `toJava`.)
      */
-    override def toCompletableFuture(): CompletableFuture[T] = {
-      this
-    }
+    override def toCompletableFuture(): CompletableFuture[T] = this
+
+    override def obtrudeValue(value: T): Unit = throw new UnsupportedOperationException("obtrudeValue may not be used on the result of toJava(scalaFuture)")
+
+    override def obtrudeException(ex: Throwable): Unit = throw new UnsupportedOperationException("obtrudeException may not be used on the result of toJava(scalaFuture)")
 
     override def get(): T = scala.concurrent.blocking(super.get())
 

--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -66,8 +66,15 @@ object FuturesConvertersImpl {
       cf
     }
 
-    override def toCompletableFuture(): CompletableFuture[T] =
-      throw new UnsupportedOperationException("this CompletionStage represents a read-only Scala Future")
+    /**
+     * @inheritdoc
+     *
+     * WARNING: completing the result of this method will not complete the underlying
+     *          Scala Future or Promise.
+     */
+    override def toCompletableFuture(): CompletableFuture[T] = {
+      this // TODO or maybe `thenApply(JF.identity())`
+    }
 
     override def toString: String = super[CompletableFuture].toString
   }

--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -6,7 +6,7 @@ package scala.concurrent.java8
 // Located in this package to access private[concurrent] members
 
 import scala.concurrent.{ Future, Promise, ExecutionContext, ExecutionContextExecutorService, ExecutionContextExecutor, impl }
-import java.util.concurrent.{ CompletionStage, Executor, ExecutorService, CompletableFuture }
+import java.util.concurrent._
 import scala.util.{ Try, Success, Failure }
 import java.util.function.{ BiConsumer, Function ⇒ JF, Consumer, BiFunction }
 
@@ -75,6 +75,10 @@ object FuturesConvertersImpl {
     override def toCompletableFuture(): CompletableFuture[T] = {
       this
     }
+
+    override def get(): T = scala.concurrent.blocking(super.get())
+
+    override def get(timeout: Long, unit: TimeUnit): T = scala.concurrent.blocking(super.get(timeout, unit))
 
     override def toString: String = super[CompletableFuture].toString
   }

--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -70,7 +70,7 @@ object FuturesConvertersImpl {
      * @inheritdoc
      *
      * WARNING: completing the result of this method will not complete the underlying
-     *          Scala Future or Promise.
+     *          Scala Future or Promise (ie, the one that that was passed to `toJava`.)
      */
     override def toCompletableFuture(): CompletableFuture[T] = {
       this // TODO or maybe `thenApply(JF.identity())`

--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -73,7 +73,7 @@ object FuturesConvertersImpl {
      *          Scala Future or Promise (ie, the one that that was passed to `toJava`.)
      */
     override def toCompletableFuture(): CompletableFuture[T] = {
-      this // TODO or maybe `thenApply(JF.identity())`
+      this
     }
 
     override def toString: String = super[CompletableFuture].toString

--- a/src/test/java/scala/compat/java8/FutureConvertersTest.java
+++ b/src/test/java/scala/compat/java8/FutureConvertersTest.java
@@ -320,23 +320,12 @@ public class FutureConvertersTest {
     @Test
     public void testToJavaThenComposeWithToJavaThenAccept() throws InterruptedException,
             ExecutionException, TimeoutException {
+        // Test case from https://github.com/scala/scala-java8-compat/issues/29
         final Promise<String> p1 = promise();
         final CompletableFuture<String> future = new CompletableFuture<>();
 
-        final CompletionStage<String> second =
-                CompletableFuture.supplyAsync(() -> "Hello").
-                        thenCompose(x -> toJava(p1.future()));
-
-        second.handle((x, t) -> {
-            if (t != null) {
-                t.printStackTrace();
-                future.completeExceptionally(t);
-            } else {
-                future.complete(x);
-            }
-            return null;
-        });
-
+        CompletableFuture.supplyAsync(() -> "Hello").
+                        thenCompose(x -> toJava(p1.future())).handle((x, t) -> future.complete(x));
         p1.success("Hello");
         assertEquals("Hello", future.get(1000, MILLISECONDS));
     }

--- a/src/test/java/scala/compat/java8/FutureConvertersTest.java
+++ b/src/test/java/scala/compat/java8/FutureConvertersTest.java
@@ -318,4 +318,27 @@ public class FutureConvertersTest {
         latch.countDown();
         assertEquals("Hello", second.toCompletableFuture().get());
     }
+
+    @Test
+    public void testToJavaToCompletableFuture() throws ExecutionException, InterruptedException {
+        final Promise<String> p = promise();
+        final CompletionStage<String> cs = toJava(p.future());
+        CompletableFuture<String> cf = cs.toCompletableFuture();
+        assertEquals("notyet", cf.getNow("notyet"));
+        p.success("done");
+        assertEquals("done", cf.get());
+    }
+
+    @Test
+    public void testToJavaToCompletableFutureDoesNotMutateUnderlyingPromise() throws ExecutionException, InterruptedException {
+        final Promise<String> p = promise();
+        Future<String> sf = p.future();
+        final CompletionStage<String> cs = toJava(sf);
+        CompletableFuture<String> cf = cs.toCompletableFuture();
+        assertEquals("notyet", cf.getNow("notyet"));
+        cf.complete("done");
+        assertEquals("done", cf.get());
+        assertFalse(sf.isCompleted());
+        assertFalse(p.isCompleted());
+    }
 }

--- a/src/test/java/scala/compat/java8/FutureConvertersTest.java
+++ b/src/test/java/scala/compat/java8/FutureConvertersTest.java
@@ -354,7 +354,7 @@ public class FutureConvertersTest {
     }
 
     @Test
-    public void testToJavaToCompletableFutureJavaCompleteCallledAfterScalaComplete() throws ExecutionException, InterruptedException {
+    public void testToJavaToCompletableFutureJavaCompleteCalledAfterScalaComplete() throws ExecutionException, InterruptedException {
         final Promise<String> p = promise();
         Future<String> sf = p.future();
         final CompletionStage<String> cs = toJava(sf);
@@ -364,5 +364,18 @@ public class FutureConvertersTest {
         assertEquals("scaladone", cf.get());
         cf.complete("javadone");
         assertEquals("scaladone", cf.get());
+    }
+
+    @Test
+    public void testToJavaToCompletableFutureJavaCompleteCalledBeforeScalaComplete() throws ExecutionException, InterruptedException {
+        final Promise<String> p = promise();
+        Future<String> sf = p.future();
+        final CompletionStage<String> cs = toJava(sf);
+        CompletableFuture<String> cf = cs.toCompletableFuture();
+        assertEquals("notyet", cf.getNow("notyet"));
+        cf.complete("javadone");
+        assertEquals("javadone", cf.get());
+        p.success("scaladone");
+        assertEquals("javadone", cf.get());
     }
 }

--- a/src/test/java/scala/compat/java8/FutureConvertersTest.java
+++ b/src/test/java/scala/compat/java8/FutureConvertersTest.java
@@ -363,4 +363,17 @@ public class FutureConvertersTest {
         assertFalse(sf.isCompleted());
         assertFalse(p.isCompleted());
     }
+
+    @Test
+    public void testToJavaToCompletableFutureJavaCompleteCallledAfterScalaComplete() throws ExecutionException, InterruptedException {
+        final Promise<String> p = promise();
+        Future<String> sf = p.future();
+        final CompletionStage<String> cs = toJava(sf);
+        CompletableFuture<String> cf = cs.toCompletableFuture();
+        assertEquals("notyet", cf.getNow("notyet"));
+        p.success("scaladone");
+        assertEquals("scaladone", cf.get());
+        cf.complete("javadone");
+        assertEquals("scaladone", cf.get());
+    }
 }

--- a/src/test/java/scala/compat/java8/FutureConvertersTest.java
+++ b/src/test/java/scala/compat/java8/FutureConvertersTest.java
@@ -378,4 +378,24 @@ public class FutureConvertersTest {
         p.success("scaladone");
         assertEquals("javadone", cf.get());
     }
+
+    @Test
+    public void testToJavaToCompletableFutureJavaObtrudeCalledBeforeScalaComplete() throws ExecutionException, InterruptedException {
+        final Promise<String> p = promise();
+        Future<String> sf = p.future();
+        final CompletionStage<String> cs = toJava(sf);
+        CompletableFuture<String> cf = cs.toCompletableFuture();
+        try {
+            cf.obtrudeValue("");
+            fail();
+        } catch (UnsupportedOperationException iae) {
+            // okay
+        }
+        try {
+            cf.obtrudeException(new Exception());
+            fail();
+        } catch (UnsupportedOperationException iae) {
+            // okay
+        }
+    }
 }


### PR DESCRIPTION
Thought I'd get the ball rolling with a PR.

Review by @jroper / @viktorklang / @rkuhn (as available)