### PR TITLE
Avoid unnecessary dependency on scala-{compiler,reflect}.jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ lazy val fnGen = (project in file("fnGen")).
   )
 
 lazy val root = (project in file(".")).
-  dependsOn(fnGen).
   settings(scalaModuleSettings: _*).
   settings(commonSettings: _*).
   settings(

--- a/build.sbt
+++ b/build.sbt
@@ -12,15 +12,15 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.11.7",
   crossScalaVersions := List("2.11.7" /* TODO, "2.12.0-M3"*/),
   organization := "org.scala-lang.modules",
-  version := "0.6.0-SNAPSHOT",
-  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+  version := "0.6.0-SNAPSHOT"
 )
 
 lazy val fnGen = (project in file("fnGen")).
   settings(commonSettings: _*).
   settings(
-    fork in run := true  // Needed if you run this project directly
+    fork in run := true,  // Needed if you run this project directly
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
   )
 
 lazy val root = (project in file(".")).


### PR DESCRIPTION
These are only needed for the code generator sub project.

Fixes #53