### PR TITLE
Improvements to Java 8 Stream support

### DIFF
--- a/src/main/java/scala/compat/java8/ScalaStreamSupport.java
+++ b/src/main/java/scala/compat/java8/ScalaStreamSupport.java
@@ -5,7 +5,7 @@ import scala.compat.java8.collectionImpl.*;
 import java.util.stream.*;
 import scala.compat.java8.runtime.CollectionInternals;
 
-public class ScalaStreaming {
+public class ScalaStreamSupport {
     /////////////////////
     // Generic Streams //
     /////////////////////
@@ -18,7 +18,7 @@ public class ScalaStreaming {
      * @param coll The IndexedSeq to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> from(scala.collection.IndexedSeq<T> coll) {
+    public static <T> Stream<T> stream(scala.collection.IndexedSeq<T> coll) {
         return StreamSupport.stream(new StepsAnyIndexedSeq<T>(coll, 0, coll.length()), false);
     }
 
@@ -30,7 +30,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K> Stream<K> fromKeys(scala.collection.immutable.HashMap<K, ? super Object> coll) {
+    public static <K> Stream<K> streamKeys(scala.collection.immutable.HashMap<K, ? super Object> coll) {
         return StreamSupport.stream(new StepsAnyImmHashMapKey<K, Object>(coll, 0, coll.size()), false);
     }
 
@@ -42,7 +42,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <V> Stream<V> fromValues(scala.collection.immutable.HashMap<? super Object, V> coll) {
+    public static <V> Stream<V> streamValues(scala.collection.immutable.HashMap<? super Object, V> coll) {
         return StreamSupport.stream(new StepsAnyImmHashMapValue<Object, V>(coll, 0, coll.size()), false);
     }
 
@@ -55,7 +55,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K, V> Stream< scala.Tuple2<K, V> > from(scala.collection.immutable.HashMap<K, V> coll) {
+    public static <K, V> Stream< scala.Tuple2<K, V> > stream(scala.collection.immutable.HashMap<K, V> coll) {
         return StreamSupport.stream(new StepsAnyImmHashMap<K, V>(coll, 0, coll.size()), false);
     }
 
@@ -67,7 +67,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashSet to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> from(scala.collection.immutable.HashSet<T> coll) {
+    public static <T> Stream<T> stream(scala.collection.immutable.HashSet<T> coll) {
         return StreamSupport.stream(new StepsAnyImmHashSet<T>(coll.iterator(), coll.size()), false);
     }
 
@@ -79,7 +79,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K> Stream<K> fromKeys(scala.collection.mutable.HashMap<K, ?> coll) {
+    public static <K> Stream<K> streamKeys(scala.collection.mutable.HashMap<K, ?> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.stream(new StepsAnyHashTableKey(tbl, 0, tbl.length), false);
     }
@@ -92,7 +92,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <V> Stream<V> fromValues(scala.collection.mutable.HashMap<? super Object, V> coll) {
+    public static <V> Stream<V> streamValues(scala.collection.mutable.HashMap<? super Object, V> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.stream(new StepsAnyDefaultHashTableValue(tbl, 0, tbl.length), false);
     }
@@ -106,7 +106,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K, V> Stream< scala.Tuple2<K, V> > from(scala.collection.mutable.HashMap<K, V> coll) {
+    public static <K, V> Stream< scala.Tuple2<K, V> > stream(scala.collection.mutable.HashMap<K, V> coll) {
         scala.collection.mutable.HashEntry< K, scala.collection.mutable.DefaultEntry<K, V> >[] tbl = 
             CollectionInternals.getTable(coll);
         return StreamSupport.stream(new StepsAnyDefaultHashTable<K, V>(tbl, 0, tbl.length), false);
@@ -120,7 +120,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashSet to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> from(scala.collection.mutable.HashSet<T> coll) {
+    public static <T> Stream<T> stream(scala.collection.mutable.HashSet<T> coll) {
         Object[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.stream(new StepsAnyFlatHashTable<T>(tbl, 0, tbl.length), false);
     }
@@ -133,7 +133,7 @@ public class ScalaStreaming {
      * @param coll The Vector to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> from(scala.collection.immutable.Vector<T> coll) {
+    public static <T> Stream<T> stream(scala.collection.immutable.Vector<T> coll) {
         return StreamSupport.stream(new StepsAnyVector<T>(coll, 0, coll.length()), false);
     }
 
@@ -141,13 +141,13 @@ public class ScalaStreaming {
      * Generates a Stream that traverses the keys of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the fromAccumulatedKeys method instead, but
+     * For efficient parallel operation, use the streamAccumulatedKeys method instead, but
      * note that this creates a new collection containing the Map's keys.
      *
      * @param coll The Map to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K> Stream<K> fromKeys(scala.collection.Map<K, ?> coll) {
+    public static <K> Stream<K> streamKeys(scala.collection.Map<K, ?> coll) {
         return StreamSupport.stream(new StepsAnyIterator<K>(coll.keysIterator()), false);
     }
 
@@ -155,13 +155,13 @@ public class ScalaStreaming {
      * Generates a Stream that traverses the values of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the fromAccumulatedValues method instead, but
+     * For efficient parallel operation, use the streamAccumulatedValues method instead, but
      * note that this creates a new collection containing the Map's values.
      *
      * @param coll The Map to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <V> Stream<V> fromValues(scala.collection.Map<?, V> coll) {
+    public static <V> Stream<V> streamValues(scala.collection.Map<?, V> coll) {
         return StreamSupport.stream(new StepsAnyIterator<V>(coll.valuesIterator()), false);
     }
 
@@ -169,13 +169,13 @@ public class ScalaStreaming {
      * Generates a Stream that traverses the key-value pairs of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the fromAccumulated method instead, but
+     * For efficient parallel operation, use the streamAccumulated method instead, but
      * note that this creates a new collection containing the Map's key-value pairs.
      *
      * @param coll The Map to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K,V> Stream< scala.Tuple2<K, V> > from(scala.collection.Map<K, V> coll) {
+    public static <K,V> Stream< scala.Tuple2<K, V> > stream(scala.collection.Map<K, V> coll) {
         return StreamSupport.stream(new StepsAnyIterator< scala.Tuple2<K, V> >(coll.iterator()), false);
     }
     
@@ -183,13 +183,13 @@ public class ScalaStreaming {
      * Generates a Stream that traverses a scala.collection.Iterator.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the fromAccumulated method instead,
+     * For efficient parallel operation, use the streamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterator.
      *
      * @param coll The scala.collection.Iterator to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> from(scala.collection.Iterator<T> coll) {
+    public static <T> Stream<T> stream(scala.collection.Iterator<T> coll) {
         return StreamSupport.stream(new StepsAnyIterator<T>(coll), false);
     }
 
@@ -197,13 +197,13 @@ public class ScalaStreaming {
      * Generates a Stream that traverses a scala.collection.Iterable.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the fromAccumulated method instead,
+     * For efficient parallel operation, use the streamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterable
      *
      * @param coll The scala.collection.Iterable to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> from(scala.collection.Iterable<T> coll) {
+    public static <T> Stream<T> stream(scala.collection.Iterable<T> coll) {
         return StreamSupport.stream(new StepsAnyIterator<T>(coll.iterator()), false);
     }
 
@@ -216,7 +216,7 @@ public class ScalaStreaming {
      * @param coll The collection to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <T> Stream<T> fromAccumulated(scala.collection.TraversableOnce<T> coll) {
+    public static <T> Stream<T> streamAccumulated(scala.collection.TraversableOnce<T> coll) {
         scala.compat.java8.collectionImpl.Accumulator<T> acc = scala.compat.java8.collectionImpl.Accumulator.from(coll);
         return StreamSupport.stream(acc.spliterator(), false);
     }
@@ -230,7 +230,7 @@ public class ScalaStreaming {
      * @param coll The map containing keys to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <K> Stream<K> fromAccumulatedKeys(scala.collection.Map<K, ?> coll) {
+    public static <K> Stream<K> streamAccumulatedKeys(scala.collection.Map<K, ?> coll) {
         scala.compat.java8.collectionImpl.Accumulator<K> acc = scala.compat.java8.collectionImpl.Accumulator.from(coll.keysIterator());
         return StreamSupport.stream(acc.spliterator(), false);
     }
@@ -244,7 +244,7 @@ public class ScalaStreaming {
      * @param coll The map containing values to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static <V> Stream<V> fromAccumulatedValues(scala.collection.Map<?, V> coll) {
+    public static <V> Stream<V> streamAccumulatedValues(scala.collection.Map<?, V> coll) {
         scala.compat.java8.collectionImpl.Accumulator<V> acc = scala.compat.java8.collectionImpl.Accumulator.from(coll.valuesIterator());
         return StreamSupport.stream(acc.spliterator(), false);
     }
@@ -261,7 +261,7 @@ public class ScalaStreaming {
      * @param coll The IndexedSeq to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFrom(scala.collection.IndexedSeq<Double> coll) {
+    public static DoubleStream doubleStream(scala.collection.IndexedSeq<Double> coll) {
         return StreamSupport.doubleStream(new StepsDoubleIndexedSeq(coll, 0, coll.length()), false);
     }
 
@@ -273,7 +273,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromKeys(scala.collection.immutable.HashMap<Double, ? super Object> coll) {
+    public static DoubleStream doubleStreamKeys(scala.collection.immutable.HashMap<Double, ? super Object> coll) {
         return StreamSupport.doubleStream(new StepsDoubleImmHashMapKey(coll, 0, coll.size()), false);
     }
 
@@ -285,7 +285,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromValues(scala.collection.immutable.HashMap<? super Object, Double> coll) {
+    public static DoubleStream doubleStreamValues(scala.collection.immutable.HashMap<? super Object, Double> coll) {
         return StreamSupport.doubleStream(new StepsDoubleImmHashMapValue(coll, 0, coll.size()), false);
     }
 
@@ -297,7 +297,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashSet to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFrom(scala.collection.immutable.HashSet<Double> coll) {
+    public static DoubleStream doubleStream(scala.collection.immutable.HashSet<Double> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.iterator();
         return StreamSupport.doubleStream(new StepsDoubleImmHashSet(iter, coll.size()), false);
     }
@@ -310,7 +310,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromKeys(scala.collection.mutable.HashMap<Double, ?> coll) {
+    public static DoubleStream doubleStreamKeys(scala.collection.mutable.HashMap<Double, ?> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.doubleStream(new StepsDoubleHashTableKey(tbl, 0, tbl.length), false);
     }
@@ -323,7 +323,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromValues(scala.collection.mutable.HashMap<? super Object, Double> coll) {
+    public static DoubleStream doubleStreamValues(scala.collection.mutable.HashMap<? super Object, Double> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.doubleStream(new StepsDoubleDefaultHashTableValue(tbl, 0, tbl.length), false);
     }
@@ -336,7 +336,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashSet to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFrom(scala.collection.mutable.HashSet<Double> coll) {
+    public static DoubleStream doubleStream(scala.collection.mutable.HashSet<Double> coll) {
         Object[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.doubleStream(new StepsDoubleFlatHashTable(tbl, 0, tbl.length), false);
     }
@@ -349,7 +349,7 @@ public class ScalaStreaming {
      * @param coll The Vector to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFrom(scala.collection.immutable.Vector<Double> coll) {
+    public static DoubleStream doubleStream(scala.collection.immutable.Vector<Double> coll) {
         scala.collection.immutable.Vector erased = (scala.collection.immutable.Vector)coll;
         return StreamSupport.doubleStream(new StepsDoubleVector(erased, 0, coll.length()), false);
     }
@@ -358,13 +358,13 @@ public class ScalaStreaming {
      * Generates a DoubleStream that traverses the double-valued keys of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the doubleFromAccumulatedKeys method instead, but
+     * For efficient parallel operation, use the doubleStreamAccumulatedKeys method instead, but
      * note that this creates a new collection containing the Map's keys.
      *
      * @param coll The Map to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromKeys(scala.collection.Map<Double, ?> coll) {
+    public static DoubleStream doubleStreamKeys(scala.collection.Map<Double, ?> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.keysIterator();
         return StreamSupport.doubleStream(new StepsDoubleIterator(iter), false);
     }
@@ -373,13 +373,13 @@ public class ScalaStreaming {
      * Generates a DoubleStream that traverses the double-valued values of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the doubleFromAccumulatedValues method instead, but
+     * For efficient parallel operation, use the doubleStreamAccumulatedValues method instead, but
      * note that this creates a new collection containing the Map's values.
      *
      * @param coll The Map to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromValues(scala.collection.Map<?, Double> coll) {
+    public static DoubleStream doubleStreamValues(scala.collection.Map<?, Double> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.valuesIterator();
         return StreamSupport.doubleStream(new StepsDoubleIterator(iter), false);
     }
@@ -388,13 +388,13 @@ public class ScalaStreaming {
      * Generates a DoubleStream that traverses a double-valued scala.collection.Iterator.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the doubleFromAccumulated method instead,
+     * For efficient parallel operation, use the doubleStreamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterator.
      *
      * @param coll The scala.collection.Iterator to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFrom(scala.collection.Iterator<Double> coll) {
+    public static DoubleStream doubleStream(scala.collection.Iterator<Double> coll) {
         return StreamSupport.doubleStream(new StepsDoubleIterator((scala.collection.Iterator)coll), false);
     }
 
@@ -402,13 +402,13 @@ public class ScalaStreaming {
      * Generates a DoubleStream that traverses a double-valued scala.collection.Iterable.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the doubleFromAccumulated method instead,
+     * For efficient parallel operation, use the doubleStreamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterable.
      *
      * @param coll The scala.collection.Iterable to traverse
      * @return     A DoubleStream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFrom(scala.collection.Iterable<Double> coll) {
+    public static DoubleStream doubleStream(scala.collection.Iterable<Double> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.iterator();        
         return StreamSupport.doubleStream(new StepsDoubleIterator(iter), false);
     }
@@ -422,7 +422,7 @@ public class ScalaStreaming {
      * @param coll The collection to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromAccumulated(scala.collection.TraversableOnce<Double> coll) {
+    public static DoubleStream doubleStreamAccumulated(scala.collection.TraversableOnce<Double> coll) {
         scala.compat.java8.collectionImpl.DoubleAccumulator acc = 
           scala.compat.java8.collectionImpl.DoubleAccumulator.from((scala.collection.TraversableOnce)coll);
         return StreamSupport.doubleStream(acc.spliterator(), false);
@@ -437,7 +437,7 @@ public class ScalaStreaming {
      * @param coll The map containing keys to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromAccumulatedKeys(scala.collection.Map<Double, ?> coll) {
+    public static DoubleStream doubleStreamAccumulatedKeys(scala.collection.Map<Double, ?> coll) {
         scala.compat.java8.collectionImpl.DoubleAccumulator acc = 
           scala.compat.java8.collectionImpl.DoubleAccumulator.from((scala.collection.Iterator)coll.keysIterator());
         return StreamSupport.doubleStream(acc.spliterator(), false);
@@ -452,7 +452,7 @@ public class ScalaStreaming {
      * @param coll The map containing values to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static DoubleStream doubleFromAccumulatedValues(scala.collection.Map<?, Double> coll) {
+    public static DoubleStream doubleStreamAccumulatedValues(scala.collection.Map<?, Double> coll) {
         scala.compat.java8.collectionImpl.DoubleAccumulator acc = 
           scala.compat.java8.collectionImpl.DoubleAccumulator.from((scala.collection.Iterator)coll.valuesIterator());
         return StreamSupport.doubleStream(acc.spliterator(), false);
@@ -470,7 +470,7 @@ public class ScalaStreaming {
      * @param coll The BitSet to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.BitSet coll) {
+    public static IntStream intStream(scala.collection.BitSet coll) {
         // Let the value class figure out the casting!
         scala.compat.java8.converterImpl.RichBitSetCanStep rbscs = 
           new scala.compat.java8.converterImpl.RichBitSetCanStep(coll);
@@ -485,7 +485,7 @@ public class ScalaStreaming {
      * @param coll The Range to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.immutable.Range coll) {
+    public static IntStream intStream(scala.collection.immutable.Range coll) {
         return StreamSupport.intStream(new scala.compat.java8.converterImpl.StepsIntRange(coll, 0, coll.length()), false);
     }
 
@@ -497,7 +497,7 @@ public class ScalaStreaming {
      * @param coll The IndexedSeq to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.IndexedSeq<Integer> coll) {
+    public static IntStream intStream(scala.collection.IndexedSeq<Integer> coll) {
         return StreamSupport.intStream(new StepsIntIndexedSeq(coll, 0, coll.length()), false);
     }
 
@@ -509,7 +509,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromKeys(scala.collection.immutable.HashMap<Integer, ? super Object> coll) {
+    public static IntStream intStreamKeys(scala.collection.immutable.HashMap<Integer, ? super Object> coll) {
         return StreamSupport.intStream(new StepsIntImmHashMapKey(coll, 0, coll.size()), false);
     }
 
@@ -521,7 +521,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromValues(scala.collection.immutable.HashMap<? super Object, Integer> coll) {
+    public static IntStream intStreamValues(scala.collection.immutable.HashMap<? super Object, Integer> coll) {
         return StreamSupport.intStream(new StepsIntImmHashMapValue(coll, 0, coll.size()), false);
     }
 
@@ -533,7 +533,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashSet to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.immutable.HashSet<Integer> coll) {
+    public static IntStream intStream(scala.collection.immutable.HashSet<Integer> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.iterator();
         return StreamSupport.intStream(new StepsIntImmHashSet(iter, coll.size()), false);
     }
@@ -546,7 +546,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromKeys(scala.collection.mutable.HashMap<Integer, ?> coll) {
+    public static IntStream intStreamKeys(scala.collection.mutable.HashMap<Integer, ?> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.intStream(new StepsIntHashTableKey(tbl, 0, tbl.length), false);
     }
@@ -559,7 +559,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromValues(scala.collection.mutable.HashMap<? super Object, Integer> coll) {
+    public static IntStream intStreamValues(scala.collection.mutable.HashMap<? super Object, Integer> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.intStream(new StepsIntDefaultHashTableValue(tbl, 0, tbl.length), false);
     }
@@ -572,7 +572,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashSet to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.mutable.HashSet<Integer> coll) {
+    public static IntStream intStream(scala.collection.mutable.HashSet<Integer> coll) {
         Object[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.intStream(new StepsIntFlatHashTable(tbl, 0, tbl.length), false);
     }
@@ -585,7 +585,7 @@ public class ScalaStreaming {
      * @param coll The Vector to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.immutable.Vector<Integer> coll) {
+    public static IntStream intStream(scala.collection.immutable.Vector<Integer> coll) {
         scala.collection.immutable.Vector erased = (scala.collection.immutable.Vector)coll;
         return StreamSupport.intStream(new StepsIntVector(erased, 0, coll.length()), false);
     }
@@ -594,13 +594,13 @@ public class ScalaStreaming {
      * Generates a IntStream that traverses the int-valued keys of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the intFromAccumulatedKeys method instead, but
+     * For efficient parallel operation, use the intStreamAccumulatedKeys method instead, but
      * note that this creates a new collection containing the Map's keys.
      *
      * @param coll The Map to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromKeys(scala.collection.Map<Integer, ?> coll) {
+    public static IntStream intStreamKeys(scala.collection.Map<Integer, ?> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.keysIterator();
         return StreamSupport.intStream(new StepsIntIterator(iter), false);
     }
@@ -609,13 +609,13 @@ public class ScalaStreaming {
      * Generates a IntStream that traverses the int-valued values of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the intFromAccumulatedValues method instead, but
+     * For efficient parallel operation, use the intStreamAccumulatedValues method instead, but
      * note that this creates a new collection containing the Map's values.
      *
      * @param coll The Map to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromValues(scala.collection.Map<?, Integer> coll) {
+    public static IntStream intStreamValues(scala.collection.Map<?, Integer> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.valuesIterator();
         return StreamSupport.intStream(new StepsIntIterator(iter), false);
     }
@@ -624,13 +624,13 @@ public class ScalaStreaming {
      * Generates a IntStream that traverses a int-valued scala.collection.Iterator.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the intFromAccumulated method instead,
+     * For efficient parallel operation, use the intStreamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterator.
      *
      * @param coll The scala.collection.Iterator to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.Iterator<Integer> coll) {
+    public static IntStream intStream(scala.collection.Iterator<Integer> coll) {
         return StreamSupport.intStream(new StepsIntIterator((scala.collection.Iterator)coll), false);
     }
 
@@ -638,13 +638,13 @@ public class ScalaStreaming {
      * Generates a IntStream that traverses a int-valued scala.collection.Iterable.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the intFromAccumulated method instead,
+     * For efficient parallel operation, use the intStreamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterable.
      *
      * @param coll The scala.collection.Iterable to traverse
      * @return     A IntStream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFrom(scala.collection.Iterable<Integer> coll) {
+    public static IntStream intStream(scala.collection.Iterable<Integer> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.iterator();        
         return StreamSupport.intStream(new StepsIntIterator(iter), false);
     }
@@ -658,7 +658,7 @@ public class ScalaStreaming {
      * @param coll The collection to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromAccumulated(scala.collection.TraversableOnce<Integer> coll) {
+    public static IntStream intStreamAccumulated(scala.collection.TraversableOnce<Integer> coll) {
         scala.compat.java8.collectionImpl.IntAccumulator acc = 
           scala.compat.java8.collectionImpl.IntAccumulator.from((scala.collection.TraversableOnce)coll);
         return StreamSupport.intStream(acc.spliterator(), false);
@@ -673,7 +673,7 @@ public class ScalaStreaming {
      * @param coll The map containing keys to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromAccumulatedKeys(scala.collection.Map<Integer, ?> coll) {
+    public static IntStream intStreamAccumulatedKeys(scala.collection.Map<Integer, ?> coll) {
         scala.compat.java8.collectionImpl.IntAccumulator acc = 
           scala.compat.java8.collectionImpl.IntAccumulator.from((scala.collection.Iterator)coll.keysIterator());
         return StreamSupport.intStream(acc.spliterator(), false);
@@ -688,7 +688,7 @@ public class ScalaStreaming {
      * @param coll The map containing values to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static IntStream intFromAccumulatedValues(scala.collection.Map<?, Integer> coll) {
+    public static IntStream intStreamAccumulatedValues(scala.collection.Map<?, Integer> coll) {
         scala.compat.java8.collectionImpl.IntAccumulator acc = 
           scala.compat.java8.collectionImpl.IntAccumulator.from((scala.collection.Iterator)coll.valuesIterator());
         return StreamSupport.intStream(acc.spliterator(), false);
@@ -706,7 +706,7 @@ public class ScalaStreaming {
      * @param coll The IndexedSeq to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFrom(scala.collection.IndexedSeq<Long> coll) {
+    public static LongStream longStream(scala.collection.IndexedSeq<Long> coll) {
         return StreamSupport.longStream(new StepsLongIndexedSeq(coll, 0, coll.length()), false);
     }
 
@@ -718,7 +718,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromKeys(scala.collection.immutable.HashMap<Long, ? super Object> coll) {
+    public static LongStream longStreamKeys(scala.collection.immutable.HashMap<Long, ? super Object> coll) {
         return StreamSupport.longStream(new StepsLongImmHashMapKey(coll, 0, coll.size()), false);
     }
 
@@ -730,7 +730,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashMap to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromValues(scala.collection.immutable.HashMap<? super Object, Long> coll) {
+    public static LongStream longStreamValues(scala.collection.immutable.HashMap<? super Object, Long> coll) {
         return StreamSupport.longStream(new StepsLongImmHashMapValue(coll, 0, coll.size()), false);
     }
 
@@ -742,7 +742,7 @@ public class ScalaStreaming {
      * @param coll The immutable.HashSet to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFrom(scala.collection.immutable.HashSet<Long> coll) {
+    public static LongStream longStream(scala.collection.immutable.HashSet<Long> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.iterator();
         return StreamSupport.longStream(new StepsLongImmHashSet(iter, coll.size()), false);
     }
@@ -755,7 +755,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromKeys(scala.collection.mutable.HashMap<Long, ?> coll) {
+    public static LongStream longStreamKeys(scala.collection.mutable.HashMap<Long, ?> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.longStream(new StepsLongHashTableKey(tbl, 0, tbl.length), false);
     }
@@ -768,7 +768,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashMap to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromValues(scala.collection.mutable.HashMap<? super Object, Long> coll) {
+    public static LongStream longStreamValues(scala.collection.mutable.HashMap<? super Object, Long> coll) {
         scala.collection.mutable.HashEntry[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.longStream(new StepsLongDefaultHashTableValue(tbl, 0, tbl.length), false);
     }
@@ -781,7 +781,7 @@ public class ScalaStreaming {
      * @param coll The mutable.HashSet to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFrom(scala.collection.mutable.HashSet<Long> coll) {
+    public static LongStream longStream(scala.collection.mutable.HashSet<Long> coll) {
         Object[] tbl = CollectionInternals.getTable(coll);
         return StreamSupport.longStream(new StepsLongFlatHashTable(tbl, 0, tbl.length), false);
     }
@@ -794,7 +794,7 @@ public class ScalaStreaming {
      * @param coll The Vector to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFrom(scala.collection.immutable.Vector<Long> coll) {
+    public static LongStream longStream(scala.collection.immutable.Vector<Long> coll) {
         scala.collection.immutable.Vector erased = (scala.collection.immutable.Vector)coll;
         return StreamSupport.longStream(new StepsLongVector(erased, 0, coll.length()), false);
     }
@@ -803,13 +803,13 @@ public class ScalaStreaming {
      * Generates a LongStream that traverses the long-valued keys of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the longFromAccumulatedKeys method instead, but
+     * For efficient parallel operation, use the longStreamAccumulatedKeys method instead, but
      * note that this creates a new collection containing the Map's keys.
      *
      * @param coll The Map to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromKeys(scala.collection.Map<Long, ?> coll) {
+    public static LongStream longStreamKeys(scala.collection.Map<Long, ?> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.keysIterator();
         return StreamSupport.longStream(new StepsLongIterator(iter), false);
     }
@@ -818,13 +818,13 @@ public class ScalaStreaming {
      * Generates a LongStream that traverses the long-valued values of a scala.collection.Map.
      * <p>
      * Only sequential operations will be efficient. 
-     * For efficient parallel operation, use the longFromAccumulatedValues method instead, but
+     * For efficient parallel operation, use the longStreamAccumulatedValues method instead, but
      * note that this creates a new collection containing the Map's values.
      *
      * @param coll The Map to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromValues(scala.collection.Map<?, Long> coll) {
+    public static LongStream longStreamValues(scala.collection.Map<?, Long> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.valuesIterator();
         return StreamSupport.longStream(new StepsLongIterator(iter), false);
     }
@@ -833,13 +833,13 @@ public class ScalaStreaming {
      * Generates a LongStream that traverses a long-valued scala.collection.Iterator.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the longFromAccumulated method instead,
+     * For efficient parallel operation, use the longStreamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterator.
      *
      * @param coll The scala.collection.Iterator to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFrom(scala.collection.Iterator<Long> coll) {
+    public static LongStream longStream(scala.collection.Iterator<Long> coll) {
         return StreamSupport.longStream(new StepsLongIterator((scala.collection.Iterator)coll), false);
     }
 
@@ -847,13 +847,13 @@ public class ScalaStreaming {
      * Generates a LongStream that traverses a long-valued scala.collection.Iterable.
      * <p>
      * Only sequential operations will be efficient.
-     * For efficient parallel operation, use the longFromAccumulated method instead,
+     * For efficient parallel operation, use the longStreamAccumulated method instead,
      * but note that this creates a copy of the contents of the Iterable.
      *
      * @param coll The scala.collection.Iterable to traverse
      * @return     A LongStream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFrom(scala.collection.Iterable<Long> coll) {
+    public static LongStream longStream(scala.collection.Iterable<Long> coll) {
         scala.collection.Iterator iter = (scala.collection.Iterator)coll.iterator();        
         return StreamSupport.longStream(new StepsLongIterator(iter), false);
     }
@@ -867,7 +867,7 @@ public class ScalaStreaming {
      * @param coll The collection to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromAccumulated(scala.collection.TraversableOnce<Long> coll) {
+    public static LongStream longStreamAccumulated(scala.collection.TraversableOnce<Long> coll) {
         scala.compat.java8.collectionImpl.LongAccumulator acc = 
           scala.compat.java8.collectionImpl.LongAccumulator.from((scala.collection.TraversableOnce)coll);
         return StreamSupport.longStream(acc.spliterator(), false);
@@ -882,7 +882,7 @@ public class ScalaStreaming {
      * @param coll The map containing keys to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromAccumulatedKeys(scala.collection.Map<Long, ?> coll) {
+    public static LongStream longStreamAccumulatedKeys(scala.collection.Map<Long, ?> coll) {
         scala.compat.java8.collectionImpl.LongAccumulator acc = 
           scala.compat.java8.collectionImpl.LongAccumulator.from((scala.collection.Iterator)coll.keysIterator());
         return StreamSupport.longStream(acc.spliterator(), false);
@@ -897,7 +897,7 @@ public class ScalaStreaming {
      * @param coll The map containing values to traverse
      * @return     A Stream view of the collection which, by default, executes sequentially.
      */
-    public static LongStream longFromAccumulatedValues(scala.collection.Map<?, Long> coll) {
+    public static LongStream longStreamAccumulatedValues(scala.collection.Map<?, Long> coll) {
         scala.compat.java8.collectionImpl.LongAccumulator acc = 
           scala.compat.java8.collectionImpl.LongAccumulator.from((scala.collection.Iterator)coll.valuesIterator());
         return StreamSupport.longStream(acc.spliterator(), false);

--- a/src/main/java/scala/compat/java8/ScalaStreamSupport.java
+++ b/src/main/java/scala/compat/java8/ScalaStreamSupport.java
@@ -5,6 +5,16 @@ import scala.compat.java8.collectionImpl.*;
 import java.util.stream.*;
 import scala.compat.java8.runtime.CollectionInternals;
 
+/**
+ * This class contains static utility methods for creating Java Streams from Scala Collections, similar
+ * to the methods in {@code java.util.stream.StreamSupport} for other Java types. It is intended for
+ * use from Java code. In Scala code, you can use the extension methods provided by
+ * {@code scala.compat.java8.StreamConverters} instead.
+ *
+ * Streams created from immutable Scala collections are also immutable. Mutable collections should
+ * not be modified concurrently. There are no guarantees for success or failure modes of existing
+ * streams in case of concurrent modifications.
+ */
 public class ScalaStreamSupport {
     /////////////////////
     // Generic Streams //

--- a/src/main/java/scala/compat/java8/runtime/CollectionInternals.java
+++ b/src/main/java/scala/compat/java8/runtime/CollectionInternals.java
@@ -1,6 +1,6 @@
 package scala.compat.java8.runtime;
 
-import scala.collection.immutable.*;  // Don't rely on this!  Refer to everything explicitly!
+// No imports! All type names are fully qualified to avoid confusion!
 
 public class CollectionInternals {
     public static <A> Object[] getTable(scala.collection.mutable.FlatHashTable<A> fht) { return fht.hashTableContents().table(); }

--- a/src/main/scala/scala/compat/java8/PrimitiveIteratorConversions.scala
+++ b/src/main/scala/scala/compat/java8/PrimitiveIteratorConversions.scala
@@ -96,13 +96,13 @@ object PrimitiveIteratorConverters {
   }
   
   /** Provides conversions from Java `Iterator` to manually specialized `PrimitiveIterator` variants, when available */
-  implicit class RichJavaIteratorToPrimitives[A](val underlying: JIterator[A]) extends AnyVal {
+  implicit final class RichJavaIteratorToPrimitives[A](private val underlying: JIterator[A]) extends AnyVal {
     /** Wraps this `java.util.Iterator` as a manually specialized variant, if possible */
     def asPrimitive[That](implicit specOp: SpecializerOfIterators[A, That]): That = specOp.fromJava(underlying)
   }
   
   /** Provides conversions from Scala `Iterator` to manually specialized `PrimitiveIterator` variants, when available */
-  implicit class RichIteratorToPrimitives[A](val underlying: Iterator[A]) extends AnyVal {
+  implicit final class RichIteratorToPrimitives[A](private val underlying: Iterator[A]) extends AnyVal {
     /** Wraps this `scala.collection.Iterator` as a manually specialized `java.util.PrimitiveIterator` variant, if possible */
     def asPrimitive[That](implicit specOp: SpecializerOfIterators[A, That]): That = specOp.fromScala(underlying)
   }

--- a/src/main/scala/scala/compat/java8/SpliteratorConverters.scala
+++ b/src/main/scala/scala/compat/java8/SpliteratorConverters.scala
@@ -17,13 +17,13 @@ package SpliteratorConverters {
 
 
 package object SpliteratorConverters extends SpliteratorConverters.Priority2SpliteratorConverters {
-  implicit class SpliteratorOfDoubleToStepper(private val underlying: Spliterator.OfDouble) extends AnyVal {
+  implicit final class SpliteratorOfDoubleToStepper(private val underlying: Spliterator.OfDouble) extends AnyVal {
     def stepper: DoubleStepper = Stepper.ofSpliterator(underlying)
   }
-  implicit class SpliteratorOfIntToStepper(private val underlying: Spliterator.OfInt) extends AnyVal {
+  implicit final class SpliteratorOfIntToStepper(private val underlying: Spliterator.OfInt) extends AnyVal {
     def stepper: IntStepper = Stepper.ofSpliterator(underlying)
   }
-  implicit class SpliteratorOfLongToStepper(private val underlying: Spliterator.OfLong) extends AnyVal {
+  implicit final class SpliteratorOfLongToStepper(private val underlying: Spliterator.OfLong) extends AnyVal {
     def stepper: LongStepper = Stepper.ofSpliterator(underlying)
   }
 }

--- a/src/main/scala/scala/compat/java8/StreamConverters.scala
+++ b/src/main/scala/scala/compat/java8/StreamConverters.scala
@@ -208,25 +208,25 @@ extends Priority1StreamConverters
 with converterImpl.Priority1StepConverters
 with converterImpl.Priority1AccumulatorConverters
 {
-  implicit class EnrichDoubleArrayWithStream(a: Array[Double])   
-  extends MakesSequentialStream[java.lang.Double, DoubleStream] with MakesParallelStream[java.lang.Double, DoubleStream] {
+  implicit final class EnrichDoubleArrayWithStream(private val a: Array[Double])
+  extends AnyVal with MakesSequentialStream[java.lang.Double, DoubleStream] with MakesParallelStream[java.lang.Double, DoubleStream] {
     def seqStream: DoubleStream = java.util.Arrays.stream(a)
     def parStream: DoubleStream = seqStream.parallel
   }
 
-  implicit class EnrichIntArrayWithStream(a: Array[Int])   
-  extends MakesSequentialStream[java.lang.Integer, IntStream] with MakesParallelStream[java.lang.Integer, IntStream] {
+  implicit final class EnrichIntArrayWithStream(private val a: Array[Int])
+  extends AnyVal with MakesSequentialStream[java.lang.Integer, IntStream] with MakesParallelStream[java.lang.Integer, IntStream] {
     def seqStream: IntStream = java.util.Arrays.stream(a)
     def parStream: IntStream = seqStream.parallel
   }
 
-  implicit class EnrichLongArrayWithStream(a: Array[Long])   
-  extends MakesSequentialStream[java.lang.Long, LongStream] with MakesParallelStream[java.lang.Long, LongStream] {
+  implicit final class EnrichLongArrayWithStream(private val a: Array[Long])
+  extends AnyVal with MakesSequentialStream[java.lang.Long, LongStream] with MakesParallelStream[java.lang.Long, LongStream] {
     def seqStream: LongStream = java.util.Arrays.stream(a)
     def parStream: LongStream = seqStream.parallel
   }
 
-  implicit val primitiveAccumulateDoubleStream = new PrimitiveStreamAccumulator[Stream[Double], DoubleAccumulator] { 
+  implicit val primitiveAccumulateDoubleStream = new PrimitiveStreamAccumulator[Stream[Double], DoubleAccumulator] {
     def streamAccumulate(stream: Stream[Double]): DoubleAccumulator = 
       stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.boxedAdder, DoubleAccumulator.merger)
   }
@@ -274,7 +274,7 @@ with converterImpl.Priority1AccumulatorConverters
   implicit val primitiveUnboxLongStream2 =
     primitiveUnboxLongStream.asInstanceOf[PrimitiveStreamUnboxer[java.lang.Long, LongStream]]
   
-  implicit class RichDoubleStream(stream: DoubleStream) {
+  implicit final class RichDoubleStream(private val stream: DoubleStream) extends AnyVal {
     def accumulate = stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.adder, DoubleAccumulator.merger)
     
     def toScala[Coll[_]](implicit cbf: collection.generic.CanBuildFrom[Nothing, Double, Coll[Double]]): Coll[Double] = {
@@ -287,7 +287,7 @@ with converterImpl.Priority1AccumulatorConverters
     }
   }
   
-  implicit class RichIntStream(stream: IntStream) {
+  implicit final class RichIntStream(private val stream: IntStream) extends AnyVal {
     def accumulate = stream.collect(IntAccumulator.supplier, IntAccumulator.adder, IntAccumulator.merger)
 
     def toScala[Coll[_]](implicit cbf: collection.generic.CanBuildFrom[Nothing, Int, Coll[Int]]): Coll[Int] = {
@@ -300,7 +300,7 @@ with converterImpl.Priority1AccumulatorConverters
     }
   }
   
-  implicit class RichLongStream(stream: LongStream) {
+  implicit final class RichLongStream(private val stream: LongStream) extends AnyVal {
     def accumulate = stream.collect(LongAccumulator.supplier, LongAccumulator.adder, LongAccumulator.merger)
 
     def toScala[Coll[_]](implicit cbf: collection.generic.CanBuildFrom[Nothing, Long, Coll[Long]]): Coll[Long] = {

--- a/src/main/scala/scala/compat/java8/StreamConverters.scala
+++ b/src/main/scala/scala/compat/java8/StreamConverters.scala
@@ -14,10 +14,20 @@ trait PrimitiveStreamUnboxer[A, S] {
   def apply(boxed: Stream[A]): S
 }
 
-trait Priority5StreamConverters {
+trait Priority3StreamConverters {
+  implicit class EnrichAnySteppableWithParStream[A, CC](cc: CC)(implicit steppize: CC => MakesStepper[AnyStepper[A] with EfficientSubstep])
+  extends MakesParallelStream[A, Stream[A]] {
+    def parStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper.anticipateParallelism, true)
+  }
+  implicit class EnrichAnyKeySteppableWithParKeyStream[K, CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[AnyStepper[K] with EfficientSubstep]) {
+    def parKeyStream: Stream[K] = StreamSupport.stream(steppize(cc).keyStepper.anticipateParallelism, true)
+  }
+  implicit class EnrichAnyValueSteppableWithParValueStream[V, CC](cc: CC)(implicit steppize: CC => MakesValueStepper[AnyStepper[V] with EfficientSubstep]) {
+    def parValueStream: Stream[V] = StreamSupport.stream(steppize(cc).valueStepper.anticipateParallelism, true)
+  }
   // Note--conversion is only to make sure implicit conversion priority is lower than alternatives.
   implicit class EnrichScalaCollectionWithSeqStream[A, CC](cc: CC)(implicit steppize: CC => MakesStepper[AnyStepper[A]])
-  extends MakesSequentialStream[A, Stream[A]] {
+    extends MakesSequentialStream[A, Stream[A]] {
     def seqStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper, false)
   }
   implicit class EnrichScalaCollectionWithKeySeqStream[K, CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[AnyStepper[K]]) {
@@ -28,94 +38,66 @@ trait Priority5StreamConverters {
   }
 }
 
-trait Priority4StreamConverters extends Priority5StreamConverters {
+trait Priority2StreamConverters extends Priority3StreamConverters {
+  implicit class EnrichDoubleSteppableWithParStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[DoubleStepper with EfficientSubstep])
+  extends MakesParallelStream[java.lang.Double, DoubleStream] {
+    def parStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper.anticipateParallelism, true)
+  }
+  implicit class EnrichDoubleKeySteppableWithParKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[DoubleStepper with EfficientSubstep]) {
+    def parKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper.anticipateParallelism, true)
+  }
+  implicit class EnrichDoubleValueSteppableWithParValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[DoubleStepper with EfficientSubstep]) {
+    def parValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper.anticipateParallelism, true)
+  }
+  implicit class EnrichIntSteppableWithParStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[IntStepper with EfficientSubstep])
+  extends MakesParallelStream[java.lang.Integer, IntStream] {
+    def parStream: IntStream = StreamSupport.intStream(steppize(cc).stepper.anticipateParallelism, true)
+  }
+  implicit class EnrichIntKeySteppableWithParKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[IntStepper with EfficientSubstep]) {
+    def parKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper.anticipateParallelism, true)
+  }
+  implicit class EnrichIntValueSteppableWithParValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[IntStepper with EfficientSubstep]) {
+    def parValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper.anticipateParallelism, true)
+  }
+  implicit class EnrichLongSteppableWithParStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[LongStepper with EfficientSubstep])
+  extends MakesParallelStream[java.lang.Long, LongStream] {
+    def parStream: LongStream = StreamSupport.longStream(steppize(cc).stepper.anticipateParallelism, true)
+  }
+  implicit class EnrichLongKeySteppableWithParKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[LongStepper with EfficientSubstep]) {
+    def parKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper.anticipateParallelism, true)
+  }
+  implicit class EnrichLongValueSteppableWithParValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[LongStepper with EfficientSubstep]) {
+    def parValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper.anticipateParallelism, true)
+  }
   implicit class EnrichScalaCollectionWithSeqDoubleStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[DoubleStepper])
-  extends MakesSequentialStream[java.lang.Double, DoubleStream] {
+    extends MakesSequentialStream[java.lang.Double, DoubleStream] {
     def seqStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper, false)
-  }  
+  }
   implicit class EnrichScalaCollectionWithSeqIntStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[IntStepper])
-  extends MakesSequentialStream[java.lang.Integer, IntStream] {
+    extends MakesSequentialStream[java.lang.Integer, IntStream] {
     def seqStream: IntStream = StreamSupport.intStream(steppize(cc).stepper, false)
-  }  
+  }
   implicit class EnrichScalaCollectionWithSeqLongStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[LongStepper])
-  extends MakesSequentialStream[java.lang.Long, LongStream] {
+    extends MakesSequentialStream[java.lang.Long, LongStream] {
     def seqStream: LongStream = StreamSupport.longStream(steppize(cc).stepper, false)
   }
   implicit class EnrichScalaCollectionWithSeqDoubleKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[DoubleStepper]) {
     def seqKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper, false)
-  }  
+  }
   implicit class EnrichScalaCollectionWithSeqIntKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[IntStepper]) {
     def seqKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper, false)
-  }  
+  }
   implicit class EnrichScalaCollectionWithSeqLongKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[LongStepper]) {
     def seqKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper, false)
   }
   implicit class EnrichScalaCollectionWithSeqDoubleValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[DoubleStepper]) {
     def seqValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper, false)
-  }  
+  }
   implicit class EnrichScalaCollectionWithSeqIntValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[IntStepper]) {
     def seqValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper, false)
-  }  
+  }
   implicit class EnrichScalaCollectionWithSeqLongValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[LongStepper]) {
     def seqValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper, false)
-  }
-}
-
-trait Priority3StreamConverters extends Priority4StreamConverters {
-  implicit class EnrichAnySteppableWithStream[A, CC](cc: CC)(implicit steppize: CC => MakesStepper[AnyStepper[A] with EfficientSubstep])
-  extends MakesSequentialStream[A, Stream[A]] with MakesParallelStream[A, Stream[A]] {
-    def seqStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper, false)
-    def parStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper.anticipateParallelism, true)
-  }
-  implicit class EnrichAnyKeySteppableWithStream[K, CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[AnyStepper[K] with EfficientSubstep]) {
-    def seqKeyStream: Stream[K] = StreamSupport.stream(steppize(cc).keyStepper, false)
-    def parKeyStream: Stream[K] = StreamSupport.stream(steppize(cc).keyStepper.anticipateParallelism, true)    
-  }
-  implicit class EnrichAnyValueSteppableWithStream[V, CC](cc: CC)(implicit steppize: CC => MakesValueStepper[AnyStepper[V] with EfficientSubstep]) {
-    def seqValueStream: Stream[V] = StreamSupport.stream(steppize(cc).valueStepper, false)
-    def parValueStream: Stream[V] = StreamSupport.stream(steppize(cc).valueStepper.anticipateParallelism, true)    
-  }
-}
-
-trait Priority2StreamConverters extends Priority3StreamConverters {
-  implicit class EnrichDoubleSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[DoubleStepper with EfficientSubstep])
-  extends MakesSequentialStream[java.lang.Double, DoubleStream] with MakesParallelStream[java.lang.Double, DoubleStream] {
-    def seqStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper, false)
-    def parStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper.anticipateParallelism, true)
-  }
-  implicit class EnrichDoubleKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[DoubleStepper with EfficientSubstep]) {
-    def seqKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper, false)
-    def parKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper.anticipateParallelism, true)
-  }
-  implicit class EnrichDoubleValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[DoubleStepper with EfficientSubstep]) {
-    def seqValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper, false)
-    def parValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper.anticipateParallelism, true)
-  }
-  implicit class EnrichIntSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[IntStepper with EfficientSubstep])
-  extends MakesSequentialStream[java.lang.Integer, IntStream] with MakesParallelStream[java.lang.Integer, IntStream] {
-    def seqStream: IntStream = StreamSupport.intStream(steppize(cc).stepper, false)
-    def parStream: IntStream = StreamSupport.intStream(steppize(cc).stepper.anticipateParallelism, true)
-  }
-  implicit class EnrichIntKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[IntStepper with EfficientSubstep]) {
-    def seqKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper, false)
-    def parKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper.anticipateParallelism, true)
-  }
-  implicit class EnrichIntValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[IntStepper with EfficientSubstep]) {
-    def seqValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper, false)
-    def parValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper.anticipateParallelism, true)
-  }
-  implicit class EnrichLongSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[LongStepper with EfficientSubstep])
-  extends MakesSequentialStream[java.lang.Long, LongStream] with MakesParallelStream[java.lang.Long, LongStream] {
-    def seqStream: LongStream = StreamSupport.longStream(steppize(cc).stepper, false)
-    def parStream: LongStream = StreamSupport.longStream(steppize(cc).stepper.anticipateParallelism, true)
-  }
-  implicit class EnrichLongKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[LongStepper with EfficientSubstep]) {
-    def seqKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper, false)
-    def parKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper.anticipateParallelism, true)
-  }
-  implicit class EnrichLongValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[LongStepper with EfficientSubstep]) {
-    def seqValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper, false)
-    def parValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper.anticipateParallelism, true)
   }
 }
 

--- a/src/main/scala/scala/compat/java8/StreamConverters.scala
+++ b/src/main/scala/scala/compat/java8/StreamConverters.scala
@@ -16,104 +16,104 @@ trait PrimitiveStreamUnboxer[A, S] {
 
 trait Priority5StreamConverters {
   // Note--conversion is only to make sure implicit conversion priority is lower than alternatives.
-  implicit class EnrichScalaCollectionWithSeqStream[A, CC](cc: CC)(implicit steppize: CC => MakesAnySeqStepper[A])
+  implicit class EnrichScalaCollectionWithSeqStream[A, CC](cc: CC)(implicit steppize: CC => MakesStepper[AnyStepper[A]])
   extends MakesSequentialStream[A, Stream[A]] {
     def seqStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper, false)
   }
-  implicit class EnrichScalaCollectionWithKeySeqStream[K, CC](cc: CC)(implicit steppize: CC => MakesAnyKeySeqStepper[K]) {
+  implicit class EnrichScalaCollectionWithKeySeqStream[K, CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[AnyStepper[K]]) {
     def seqKeyStream: Stream[K] = StreamSupport.stream(steppize(cc).keyStepper, false)
   }
-  implicit class EnrichScalaCollectionWithValueSeqStream[V, CC](cc: CC)(implicit steppize: CC => MakesAnyValueSeqStepper[V]) {
+  implicit class EnrichScalaCollectionWithValueSeqStream[V, CC](cc: CC)(implicit steppize: CC => MakesValueStepper[AnyStepper[V]]) {
     def seqValueStream: Stream[V] = StreamSupport.stream(steppize(cc).valueStepper, false)
   }
 }
 
 trait Priority4StreamConverters extends Priority5StreamConverters {
-  implicit class EnrichScalaCollectionWithSeqDoubleStream[CC](cc: CC)(implicit steppize: CC => MakesDoubleSeqStepper)
+  implicit class EnrichScalaCollectionWithSeqDoubleStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[DoubleStepper])
   extends MakesSequentialStream[java.lang.Double, DoubleStream] {
     def seqStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper, false)
   }  
-  implicit class EnrichScalaCollectionWithSeqIntStream[CC](cc: CC)(implicit steppize: CC => MakesIntSeqStepper) 
+  implicit class EnrichScalaCollectionWithSeqIntStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[IntStepper])
   extends MakesSequentialStream[java.lang.Integer, IntStream] {
     def seqStream: IntStream = StreamSupport.intStream(steppize(cc).stepper, false)
   }  
-  implicit class EnrichScalaCollectionWithSeqLongStream[CC](cc: CC)(implicit steppize: CC => MakesLongSeqStepper) 
+  implicit class EnrichScalaCollectionWithSeqLongStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[LongStepper])
   extends MakesSequentialStream[java.lang.Long, LongStream] {
     def seqStream: LongStream = StreamSupport.longStream(steppize(cc).stepper, false)
   }
-  implicit class EnrichScalaCollectionWithSeqDoubleKeyStream[CC](cc: CC)(implicit steppize: CC => MakesDoubleKeySeqStepper) {
+  implicit class EnrichScalaCollectionWithSeqDoubleKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[DoubleStepper]) {
     def seqKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper, false)
   }  
-  implicit class EnrichScalaCollectionWithSeqIntKeyStream[CC](cc: CC)(implicit steppize: CC => MakesIntKeySeqStepper) {
+  implicit class EnrichScalaCollectionWithSeqIntKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[IntStepper]) {
     def seqKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper, false)
   }  
-  implicit class EnrichScalaCollectionWithSeqLongKeyStream[CC](cc: CC)(implicit steppize: CC => MakesLongKeySeqStepper) {
+  implicit class EnrichScalaCollectionWithSeqLongKeyStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[LongStepper]) {
     def seqKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper, false)
   }
-  implicit class EnrichScalaCollectionWithSeqDoubleValueStream[CC](cc: CC)(implicit steppize: CC => MakesDoubleValueSeqStepper) {
+  implicit class EnrichScalaCollectionWithSeqDoubleValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[DoubleStepper]) {
     def seqValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper, false)
   }  
-  implicit class EnrichScalaCollectionWithSeqIntValueStream[CC](cc: CC)(implicit steppize: CC => MakesIntValueSeqStepper) {
+  implicit class EnrichScalaCollectionWithSeqIntValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[IntStepper]) {
     def seqValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper, false)
   }  
-  implicit class EnrichScalaCollectionWithSeqLongValueStream[CC](cc: CC)(implicit steppize: CC => MakesLongValueSeqStepper) {
+  implicit class EnrichScalaCollectionWithSeqLongValueStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[LongStepper]) {
     def seqValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper, false)
   }
 }
 
 trait Priority3StreamConverters extends Priority4StreamConverters {
-  implicit class EnrichAnySteppableWithStream[A, CC](cc: CC)(implicit steppize: CC => MakesAnyStepper[A]) 
+  implicit class EnrichAnySteppableWithStream[A, CC](cc: CC)(implicit steppize: CC => MakesStepper[AnyStepper[A] with EfficientSubstep])
   extends MakesSequentialStream[A, Stream[A]] with MakesParallelStream[A, Stream[A]] {
     def seqStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper, false)
     def parStream: Stream[A] = StreamSupport.stream(steppize(cc).stepper.anticipateParallelism, true)
   }
-  implicit class EnrichAnyKeySteppableWithStream[K, CC](cc: CC)(implicit steppize: CC => MakesAnyKeyStepper[K]) {
+  implicit class EnrichAnyKeySteppableWithStream[K, CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[AnyStepper[K] with EfficientSubstep]) {
     def seqKeyStream: Stream[K] = StreamSupport.stream(steppize(cc).keyStepper, false)
     def parKeyStream: Stream[K] = StreamSupport.stream(steppize(cc).keyStepper.anticipateParallelism, true)    
   }
-  implicit class EnrichAnyValueSteppableWithStream[V, CC](cc: CC)(implicit steppize: CC => MakesAnyValueStepper[V]) {
+  implicit class EnrichAnyValueSteppableWithStream[V, CC](cc: CC)(implicit steppize: CC => MakesValueStepper[AnyStepper[V] with EfficientSubstep]) {
     def seqValueStream: Stream[V] = StreamSupport.stream(steppize(cc).valueStepper, false)
     def parValueStream: Stream[V] = StreamSupport.stream(steppize(cc).valueStepper.anticipateParallelism, true)    
   }
 }
 
 trait Priority2StreamConverters extends Priority3StreamConverters {
-  implicit class EnrichDoubleSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesDoubleStepper)  
+  implicit class EnrichDoubleSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[DoubleStepper with EfficientSubstep])
   extends MakesSequentialStream[java.lang.Double, DoubleStream] with MakesParallelStream[java.lang.Double, DoubleStream] {
     def seqStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper, false)
     def parStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).stepper.anticipateParallelism, true)
   }
-  implicit class EnrichDoubleKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesDoubleKeyStepper) {
+  implicit class EnrichDoubleKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[DoubleStepper with EfficientSubstep]) {
     def seqKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper, false)
     def parKeyStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).keyStepper.anticipateParallelism, true)
   }
-  implicit class EnrichDoubleValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesDoubleValueStepper) {
+  implicit class EnrichDoubleValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[DoubleStepper with EfficientSubstep]) {
     def seqValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper, false)
     def parValueStream: DoubleStream = StreamSupport.doubleStream(steppize(cc).valueStepper.anticipateParallelism, true)
   }
-  implicit class EnrichIntSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesIntStepper)   
+  implicit class EnrichIntSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[IntStepper with EfficientSubstep])
   extends MakesSequentialStream[java.lang.Integer, IntStream] with MakesParallelStream[java.lang.Integer, IntStream] {
     def seqStream: IntStream = StreamSupport.intStream(steppize(cc).stepper, false)
     def parStream: IntStream = StreamSupport.intStream(steppize(cc).stepper.anticipateParallelism, true)
   }
-  implicit class EnrichIntKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesIntKeyStepper) {
+  implicit class EnrichIntKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[IntStepper with EfficientSubstep]) {
     def seqKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper, false)
     def parKeyStream: IntStream = StreamSupport.intStream(steppize(cc).keyStepper.anticipateParallelism, true)
   }
-  implicit class EnrichIntValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesIntValueStepper) {
+  implicit class EnrichIntValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[IntStepper with EfficientSubstep]) {
     def seqValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper, false)
     def parValueStream: IntStream = StreamSupport.intStream(steppize(cc).valueStepper.anticipateParallelism, true)
   }
-  implicit class EnrichLongSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesLongStepper)   
+  implicit class EnrichLongSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesStepper[LongStepper with EfficientSubstep])
   extends MakesSequentialStream[java.lang.Long, LongStream] with MakesParallelStream[java.lang.Long, LongStream] {
     def seqStream: LongStream = StreamSupport.longStream(steppize(cc).stepper, false)
     def parStream: LongStream = StreamSupport.longStream(steppize(cc).stepper.anticipateParallelism, true)
   }
-  implicit class EnrichLongKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesLongKeyStepper) {
+  implicit class EnrichLongKeySteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesKeyStepper[LongStepper with EfficientSubstep]) {
     def seqKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper, false)
     def parKeyStream: LongStream = StreamSupport.longStream(steppize(cc).keyStepper.anticipateParallelism, true)
   }
-  implicit class EnrichLongValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesLongValueStepper) {
+  implicit class EnrichLongValueSteppableWithStream[CC](cc: CC)(implicit steppize: CC => MakesValueStepper[LongStepper with EfficientSubstep]) {
     def seqValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper, false)
     def parValueStream: LongStream = StreamSupport.longStream(steppize(cc).valueStepper.anticipateParallelism, true)
   }

--- a/src/main/scala/scala/compat/java8/collectionImpl/DoubleAccumulator.scala
+++ b/src/main/scala/scala/compat/java8/collectionImpl/DoubleAccumulator.scala
@@ -246,7 +246,7 @@ private[java8] class DoubleAccumulatorStepper(private val acc: DoubleAccumulator
     i = 0
   }
     
-  def characteristics = ORDERED | SIZED | SUBSIZED
+  def characteristics = ORDERED | SIZED | SUBSIZED | NONNULL
   
   def estimateSize = N
 

--- a/src/main/scala/scala/compat/java8/collectionImpl/IntAccumulator.scala
+++ b/src/main/scala/scala/compat/java8/collectionImpl/IntAccumulator.scala
@@ -253,7 +253,7 @@ private[java8] class IntAccumulatorStepper(private val acc: IntAccumulator) exte
     i = 0
   }
   
-  def characteristics = ORDERED | SIZED | SUBSIZED
+  def characteristics = ORDERED | SIZED | SUBSIZED | NONNULL
   
   def estimateSize = N
 

--- a/src/main/scala/scala/compat/java8/collectionImpl/LongAccumulator.scala
+++ b/src/main/scala/scala/compat/java8/collectionImpl/LongAccumulator.scala
@@ -247,7 +247,7 @@ private[java8] class LongAccumulatorStepper(private val acc: LongAccumulator) ex
     i = 0
   }
   
-  def characteristics = ORDERED | SIZED | SUBSIZED
+  def characteristics = ORDERED | SIZED | SUBSIZED | NONNULL
   
   def estimateSize = N
 

--- a/src/main/scala/scala/compat/java8/collectionImpl/Stepper.scala
+++ b/src/main/scala/scala/compat/java8/collectionImpl/Stepper.scala
@@ -53,7 +53,7 @@ trait EfficientSubstep {}
 
 /** Provides functionality for Stepper while keeping track of a more precise type of the collection.
   */
-trait StepperLike[@specialized(Double, Int, Long) A, +CC] { self =>
+trait StepperLike[@specialized(Double, Int, Long) A, +CC] { self: CC =>
   /** Characteristics are bit flags that indicate runtime characteristics of this Stepper.
     *
     * - `Distinct` means that no duplicates exist
@@ -89,9 +89,6 @@ trait StepperLike[@specialized(Double, Int, Long) A, +CC] { self =>
     * possible or not advisable, `substep()` will return `null`.
     */
   def substep(): CC
-
-  /** Returns the precise underlying type of this `Stepper`. */
-  def typedPrecisely: CC
 
   /** Warns this `Stepper` that it is likely to be used in a parallel context (used for efficiency only) */
   def anticipateParallelism: this.type = this
@@ -236,8 +233,7 @@ trait AnyStepper[A] extends Stepper[A] with java.util.Iterator[A] with Spliterat
   def nextStep = next
   def tryAdvance(c: java.util.function.Consumer[_ >: A]): Boolean = if (hasNext) { c.accept(next); true } else false
   def tryStep(f: A => Unit): Boolean = if (hasNext) { f(next); true } else false
-  def trySplit() = substep match { case null => null; case x => x.typedPrecisely }
-  final def typedPrecisely: AnyStepper[A] = this
+  def trySplit() = substep
   override def spliterator: Spliterator[A] = this
   def seqStream: java.util.stream.Stream[A] = java.util.stream.StreamSupport.stream(this, false)
   def parStream: java.util.stream.Stream[A] = java.util.stream.StreamSupport.stream(this, true)
@@ -253,8 +249,7 @@ trait DoubleStepper extends Stepper[Double] with java.util.PrimitiveIterator.OfD
   def tryAdvance(c: java.util.function.Consumer[_ >: java.lang.Double]): Boolean = if (hasNext) { c.accept(java.lang.Double.valueOf(nextDouble)); true } else false
   def tryAdvance(c: java.util.function.DoubleConsumer): Boolean = if (hasNext) { c.accept(nextDouble); true } else false
   def tryStep(f: Double => Unit): Boolean = if (hasNext) { f(nextDouble); true } else false
-  def trySplit() = substep match { case null => null; case x => x.typedPrecisely }
-  final def typedPrecisely: DoubleStepper = this
+  def trySplit() = substep
   override def spliterator: Spliterator[Double] = this.asInstanceOf[Spliterator[Double]]  // Scala and Java disagree about whether it's java.lang.Double or double
   def seqStream: java.util.stream.DoubleStream = java.util.stream.StreamSupport.doubleStream(this, false)
   def parStream: java.util.stream.DoubleStream = java.util.stream.StreamSupport.doubleStream(this, true)
@@ -270,8 +265,7 @@ trait IntStepper extends Stepper[Int] with java.util.PrimitiveIterator.OfInt wit
   def tryAdvance(c: java.util.function.Consumer[_ >: java.lang.Integer]): Boolean = if (hasNext) { c.accept(java.lang.Integer.valueOf(nextInt)); true } else false
   def tryAdvance(c: java.util.function.IntConsumer): Boolean = if (hasNext) { c.accept(nextInt); true } else false
   def tryStep(f: Int => Unit): Boolean = if (hasNext) { f(nextInt); true } else false
-  def trySplit() = substep match { case null => null; case x => x.typedPrecisely }
-  final def typedPrecisely = this
+  def trySplit() = substep
   override def spliterator: Spliterator[Int] = this.asInstanceOf[Spliterator[Int]]  // Scala and Java disagree about whether it's java.lang.Integer or int
   def seqStream: java.util.stream.IntStream = java.util.stream.StreamSupport.intStream(this, false)
   def parStream: java.util.stream.IntStream = java.util.stream.StreamSupport.intStream(this, true)
@@ -287,8 +281,7 @@ trait LongStepper extends Stepper[Long] with java.util.PrimitiveIterator.OfLong 
   def tryAdvance(c: java.util.function.Consumer[_ >: java.lang.Long]): Boolean = if (hasNext) { c.accept(java.lang.Long.valueOf(nextLong)); true } else false
   def tryAdvance(c: java.util.function.LongConsumer): Boolean = if (hasNext) { c.accept(nextLong); true } else false
   def tryStep(f: Long => Unit): Boolean = if (hasNext) { f(nextLong); true } else false
-  def trySplit() = substep match { case null => null; case x => x.typedPrecisely }
-  final def typedPrecisely = this
+  def trySplit() = substep
   override def spliterator: Spliterator[Long] = this.asInstanceOf[Spliterator[Long]]  // Scala and Java disagree about whether it's java.lang.Long or long
   def seqStream: java.util.stream.LongStream = java.util.stream.StreamSupport.longStream(this, false)
   def parStream: java.util.stream.LongStream = java.util.stream.StreamSupport.longStream(this, true)

--- a/src/main/scala/scala/compat/java8/converterImpl/MakesSteppers.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/MakesSteppers.scala
@@ -11,21 +11,21 @@ trait MakesSequentialStream[A, SS <: java.util.stream.BaseStream[A, SS]] extends
 }
 
 /** Classes or objects implementing this trait create streams suitable for parallel use */
-trait MakesParallelStream[A, SS <: java.util.stream.BaseStream[A, SS]] extends Any with MakesSequentialStream[A, SS] {
+trait MakesParallelStream[A, SS <: java.util.stream.BaseStream[A, SS]] extends Any {
   def parStream: SS
 }
 
-trait MakesStepper[T <: Stepper[_]] extends Any {
+trait MakesStepper[+T <: Stepper[_]] extends Any {
   /** Generates a fresh stepper of type `T` */
   def stepper: T
 }
 
-trait MakesKeyStepper[T <: Stepper[_]] extends Any {
+trait MakesKeyStepper[+T <: Stepper[_]] extends Any {
   /** Generates a fresh stepper of type `T` over map keys */
   def keyStepper: T
 }
 
-trait MakesValueStepper[T <: Stepper[_]] extends Any {
+trait MakesValueStepper[+T <: Stepper[_]] extends Any {
   /** Generates a fresh stepper of type `T` over map values */
   def valueStepper: T
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/MakesSteppers.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/MakesSteppers.scala
@@ -15,146 +15,17 @@ trait MakesParallelStream[A, SS <: java.util.stream.BaseStream[A, SS]] extends A
   def parStream: SS
 }
 
-/** Classes or objects implementing this trait create generic steppers suitable for sequential use. */
-trait MakesAnySeqStepper[A] extends Any {
-  /** Generates a fresh stepper over `A`s suitable for sequential use */
-  def stepper: AnyStepper[A] 
+trait MakesStepper[T <: Stepper[_]] extends Any {
+  /** Generates a fresh stepper of type `T` */
+  def stepper: T
 }
 
-/** Classes or objects implementing this trait create generic steppers for map keys suitable for sequential use. */
-trait MakesAnyKeySeqStepper[A] extends Any {
-  /** Generates a fresh stepper over map keys of type `A` suitable for sequential use */
-  def keyStepper: AnyStepper[A] 
+trait MakesKeyStepper[T <: Stepper[_]] extends Any {
+  /** Generates a fresh stepper of type `T` over map keys */
+  def keyStepper: T
 }
 
-/** Classes or objects implementing this trait create generic steppers for map values suitable for sequential use. */
-trait MakesAnyValueSeqStepper[A] extends Any {
-  /** Generates a fresh stepper over map values of type `A` suitable for sequential use */
-  def valueStepper: AnyStepper[A] 
-}
-
-/** Classes or objects implementing this trait create `Double` steppers suitable for sequential use. */
-trait MakesDoubleSeqStepper extends Any {
-  /** Generates a fresh stepper over `Double`s suitable for sequential use */
-  def stepper: DoubleStepper 
-}
-
-/** Classes or objects implementing this trait create `Double` steppers for map keys suitable for sequential use. */
-trait MakesDoubleKeySeqStepper extends Any {
-  /** Generates a fresh stepper over map keys of type `Double` suitable for sequential use */
-  def keyStepper: DoubleStepper 
-}
-
-/** Classes or objects implementing this trait create `Double` steppers  for map values suitable for sequential use. */
-trait MakesDoubleValueSeqStepper extends Any {
-  /** Generates a fresh stepper over map values of type `Double` suitable for sequential use */
-  def valueStepper: DoubleStepper 
-}
-
-/** Classes or objects implementing this trait create `Int` steppers suitable for sequential use. */
-trait MakesIntSeqStepper extends Any {
-  /** Generates a fresh stepper over `Int`s suitable for sequential use */
-  def stepper: IntStepper 
-}
-
-/** Classes or objects implementing this trait create `Int` steppers for map keys suitable for sequential use. */
-trait MakesIntKeySeqStepper extends Any {
-  /** Generates a fresh stepper over map keys of type `Int` suitable for sequential use */
-  def keyStepper: IntStepper 
-}
-
-/** Classes or objects implementing this trait create `Int` steppers for map values suitable for sequential use. */
-trait MakesIntValueSeqStepper extends Any {
-  /** Generates a fresh stepper over map values of type `Int` suitable for sequential use */
-  def valueStepper: IntStepper 
-}
-
-/** Classes or objects implementing this trait create `Long` steppers suitable for sequential use. */
-trait MakesLongSeqStepper extends Any {
-  /** Generates a fresh stepper over `Long`s suitable for sequential use */
-  def stepper: LongStepper 
-}
-
-/** Classes or objects implementing this trait create `Long` steppers for map keys suitable for sequential use. */
-trait MakesLongKeySeqStepper extends Any {
-  /** Generates a fresh stepper over map keys of type `Long` suitable for sequential use */
-  def keyStepper: LongStepper 
-}
-
-/** Classes or objects implementing this trait create `Long` steppers for map values suitable for sequential use. */
-trait MakesLongValueSeqStepper extends Any {
-  /** Generates a fresh stepper over map values of type `Long` suitable for sequential use */
-  def valueStepper: LongStepper 
-}
-
-/** Classes or objects implementing this trait create generic steppers suitable for sequential or parallel use. */
-trait MakesAnyStepper[A] extends Any {
-  /** Generates a fresh stepper over `A`s that can be efficiently subdivided */
-  def stepper: AnyStepper[A] with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create generic steppers for map keys suitable for sequential or parallel use. */
-trait MakesAnyKeyStepper[A] extends Any {
-  /** Generates a fresh stepper over map keys of type `A` that can be efficiently subdivided */
-  def keyStepper: AnyStepper[A] with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create generic steppers for map values suitable for sequential or parallel use. */
-trait MakesAnyValueStepper[A] extends Any {
-  /** Generates a fresh stepper over map values of type `A` that can be efficiently subdivided */
-  def valueStepper: AnyStepper[A] with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Double` steppers suitable for sequential or parallel use. */
-trait MakesDoubleStepper extends Any {
-  /** Generates a fresh stepper over `Double`s that can be efficiently subdivided */
-  def stepper: DoubleStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Double` steppers for map keys suitable for sequential or parallel use. */
-trait MakesDoubleKeyStepper extends Any {
-  /** Generates a fresh stepper over map keys of type `Double` that can be efficiently subdivided */
-  def keyStepper: DoubleStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Double` steppers for map values suitable for sequential or parallel use. */
-trait MakesDoubleValueStepper extends Any {
-  /** Generates a fresh stepper over map values of type `Double` that can be efficiently subdivided */
-  def valueStepper: DoubleStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Int` steppers suitable for sequential or parallel use. */
-trait MakesIntStepper extends Any {
-  /** Generates a fresh stepper over `Int`s that can be efficiently subdivided */
-  def stepper: IntStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Int` steppers for map keys suitable for sequential or parallel use. */
-trait MakesIntKeyStepper extends Any {
-  /** Generates a fresh stepper over map keys of type `Int` that can be efficiently subdivided */
-  def keyStepper: IntStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Int` steppers for map values suitable for sequential or parallel use. */
-trait MakesIntValueStepper extends Any {
-  /** Generates a fresh stepper over map values of type `Int` that can be efficiently subdivided */
-  def valueStepper: IntStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Long` steppers suitable for sequential or parallel use. */
-trait MakesLongStepper extends Any {
-  /** Generates a fresh stepper over `Long`s that can be efficiently subdivided */
-  def stepper: LongStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Long` steppers for map keys suitable for sequential or parallel use. */
-trait MakesLongKeyStepper extends Any {
-  /** Generates a fresh stepper over map keys of type `Long` that can be efficiently subdivided */
-  def keyStepper: LongStepper with EfficientSubstep
-}
-
-/** Classes or objects implementing this trait create `Long` steppers for map values suitable for sequential or parallel use. */
-trait MakesLongValueStepper extends Any {
-  /** Generates a fresh stepper over map values of type `Long` that can be efficiently subdivided */
-  def valueStepper: LongStepper with EfficientSubstep
+trait MakesValueStepper[T <: Stepper[_]] extends Any {
+  /** Generates a fresh stepper of type `T` over map values */
+  def valueStepper: T
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsArray.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsArray.scala
@@ -81,46 +81,46 @@ extends StepsLongLikeIndexed[StepsLongArray](_i0, _iN) {
 // Value class adapters //
 //////////////////////////
 
-final class RichArrayAnyCanStep[A](private val underlying: Array[A]) extends AnyVal with MakesAnyStepper[A] {
+final class RichArrayAnyCanStep[A](private val underlying: Array[A]) extends AnyVal with MakesStepper[AnyStepper[A] with EfficientSubstep] {
   @inline def stepper: AnyStepper[A] with EfficientSubstep = new StepsAnyArray[A](underlying, 0, underlying.length)
 }
 
-final class RichArrayObjectCanStep[A <: Object](private val underlying: Array[A]) extends AnyVal with MakesAnyStepper[A] {
+final class RichArrayObjectCanStep[A <: Object](private val underlying: Array[A]) extends AnyVal with MakesStepper[AnyStepper[A] with EfficientSubstep] {
   @inline def stepper: AnyStepper[A] with EfficientSubstep = new StepsObjectArray[A](underlying, 0, underlying.length)
 }
 
-final class RichArrayUnitCanStep(private val underlying: Array[Unit]) extends AnyVal with MakesAnyStepper[Unit] {
+final class RichArrayUnitCanStep(private val underlying: Array[Unit]) extends AnyVal with MakesStepper[AnyStepper[Unit] with EfficientSubstep] {
   @inline def stepper: AnyStepper[Unit] with EfficientSubstep = new StepsUnitArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayBooleanCanStep(private val underlying: Array[Boolean]) extends AnyVal with MakesAnyStepper[Boolean] {
+final class RichArrayBooleanCanStep(private val underlying: Array[Boolean]) extends AnyVal with MakesStepper[AnyStepper[Boolean] with EfficientSubstep] {
   @inline def stepper: AnyStepper[Boolean] with EfficientSubstep = new StepsBoxedBooleanArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayByteCanStep(private val underlying: Array[Byte]) extends AnyVal with MakesAnyStepper[Byte] {
+final class RichArrayByteCanStep(private val underlying: Array[Byte]) extends AnyVal with MakesStepper[AnyStepper[Byte] with EfficientSubstep] {
   @inline def stepper: AnyStepper[Byte] with EfficientSubstep = new StepsBoxedByteArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayCharCanStep(private val underlying: Array[Char]) extends AnyVal with MakesAnyStepper[Char] {
+final class RichArrayCharCanStep(private val underlying: Array[Char]) extends AnyVal with MakesStepper[AnyStepper[Char] with EfficientSubstep] {
   @inline def stepper: AnyStepper[Char] with EfficientSubstep = new StepsBoxedCharArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayShortCanStep(private val underlying: Array[Short]) extends AnyVal with MakesAnyStepper[Short] {
+final class RichArrayShortCanStep(private val underlying: Array[Short]) extends AnyVal with MakesStepper[AnyStepper[Short] with EfficientSubstep] {
   @inline def stepper: AnyStepper[Short] with EfficientSubstep = new StepsBoxedShortArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayFloatCanStep(private val underlying: Array[Float]) extends AnyVal with MakesAnyStepper[Float] {
+final class RichArrayFloatCanStep(private val underlying: Array[Float]) extends AnyVal with MakesStepper[AnyStepper[Float] with EfficientSubstep] {
   @inline def stepper: AnyStepper[Float] with EfficientSubstep = new StepsBoxedFloatArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayDoubleCanStep(private val underlying: Array[Double]) extends AnyVal with MakesDoubleStepper {
+final class RichArrayDoubleCanStep(private val underlying: Array[Double]) extends AnyVal with MakesStepper[DoubleStepper with EfficientSubstep] {
   @inline def stepper: DoubleStepper with EfficientSubstep = new StepsDoubleArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayIntCanStep(private val underlying: Array[Int]) extends AnyVal with MakesIntStepper {
+final class RichArrayIntCanStep(private val underlying: Array[Int]) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = new StepsIntArray(underlying, 0, underlying.length)
 }
 
-final class RichArrayLongCanStep(private val underlying: Array[Long]) extends AnyVal with MakesLongStepper {
+final class RichArrayLongCanStep(private val underlying: Array[Long]) extends AnyVal with MakesStepper[LongStepper with EfficientSubstep] {
   @inline def stepper: LongStepper with EfficientSubstep = new StepsLongArray(underlying, 0, underlying.length)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsBitSet.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsBitSet.scala
@@ -53,7 +53,7 @@ extends StepsIntLikeSliced[Array[Long], StepsIntBitSet](_underlying, _i0, _iN) {
 // Value class adapter //
 /////////////////////////
 
-final class RichBitSetCanStep(private val underlying: collection.BitSet) extends AnyVal with MakesIntStepper {
+final class RichBitSetCanStep(private val underlying: collection.BitSet) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   def stepper: IntStepper with EfficientSubstep = {
     val bits: Array[Long] = underlying match {
       case m: collection.mutable.BitSet => CollectionInternals.getBitSetInternals(m)

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsFlatHashTable.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsFlatHashTable.scala
@@ -39,28 +39,28 @@ extends StepsLongLikeGapped[StepsLongFlatHashTable](_underlying, _i0, _iN) {
 // Value class adapters //
 //////////////////////////
 
-final class RichFlatHashTableCanStep[A](private val underlying: collection.mutable.FlatHashTable[A]) extends AnyVal with MakesAnyStepper[A] {
+final class RichFlatHashTableCanStep[A](private val underlying: collection.mutable.FlatHashTable[A]) extends AnyVal with MakesStepper[AnyStepper[A] with EfficientSubstep] {
   @inline def stepper: AnyStepper[A] with EfficientSubstep = {
     val tbl = CollectionInternals.getTable(underlying)
     new StepsAnyFlatHashTable(tbl, 0, tbl.length)
   }
 }
 
-final class RichDoubleFlatHashTableCanStep(private val underlying: collection.mutable.FlatHashTable[Double]) extends AnyVal with MakesDoubleStepper {
+final class RichDoubleFlatHashTableCanStep(private val underlying: collection.mutable.FlatHashTable[Double]) extends AnyVal with MakesStepper[DoubleStepper with EfficientSubstep] {
   @inline def stepper: DoubleStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable(underlying)
     new StepsDoubleFlatHashTable(tbl, 0, tbl.length)
   }
 }
 
-final class RichIntFlatHashTableCanStep(private val underlying: collection.mutable.FlatHashTable[Int]) extends AnyVal with MakesIntStepper {
+final class RichIntFlatHashTableCanStep(private val underlying: collection.mutable.FlatHashTable[Int]) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable(underlying)
     new StepsIntFlatHashTable(tbl, 0, tbl.length)
   }
 }
 
-final class RichLongFlatHashTableCanStep(private val underlying: collection.mutable.FlatHashTable[Long]) extends AnyVal with MakesLongStepper {
+final class RichLongFlatHashTableCanStep(private val underlying: collection.mutable.FlatHashTable[Long]) extends AnyVal with MakesStepper[LongStepper with EfficientSubstep] {
   @inline def stepper: LongStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable(underlying)
     new StepsLongFlatHashTable(tbl, 0, tbl.length)

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsHashTable.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsHashTable.scala
@@ -141,7 +141,7 @@ extends StepsLongLikeGapped[StepsLongLinkedHashTableValue[K]](_underlying.asInst
 // Steppers for keys (type of HashEntry doesn't matter)
 
 final class RichHashTableKeyCanStep[K, HE >: Null <: collection.mutable.HashEntry[K, HE]](private val underlying: collection.mutable.HashTable[K, HE])
-extends AnyVal with MakesAnyKeyStepper[K] {
+extends AnyVal with MakesKeyStepper[AnyStepper[K] with EfficientSubstep] {
   @inline def keyStepper: AnyStepper[K] with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, HE](underlying)
     new StepsAnyHashTableKey(tbl, 0, tbl.length)
@@ -149,7 +149,7 @@ extends AnyVal with MakesAnyKeyStepper[K] {
 }
 
 final class RichHashTableDoubleKeyCanStep[HE >: Null <: collection.mutable.HashEntry[Double, HE]](private val underlying: collection.mutable.HashTable[Double, HE])
-extends AnyVal with MakesDoubleKeyStepper {
+extends AnyVal with MakesKeyStepper[DoubleStepper with EfficientSubstep] {
   @inline def keyStepper: DoubleStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[Double, HE](underlying)
     new StepsDoubleHashTableKey(tbl, 0, tbl.length)
@@ -157,7 +157,7 @@ extends AnyVal with MakesDoubleKeyStepper {
 }
 
 final class RichHashTableIntKeyCanStep[HE >: Null <: collection.mutable.HashEntry[Int, HE]](private val underlying: collection.mutable.HashTable[Int, HE])
-extends AnyVal with MakesIntKeyStepper {
+extends AnyVal with MakesKeyStepper[IntStepper with EfficientSubstep] {
   @inline def keyStepper: IntStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[Int, HE](underlying)
     new StepsIntHashTableKey(tbl, 0, tbl.length)
@@ -165,7 +165,7 @@ extends AnyVal with MakesIntKeyStepper {
 }
 
 final class RichHashTableLongKeyCanStep[HE >: Null <: collection.mutable.HashEntry[Long, HE]](private val underlying: collection.mutable.HashTable[Long, HE])
-extends AnyVal with MakesLongKeyStepper {
+extends AnyVal with MakesKeyStepper[LongStepper with EfficientSubstep] {
   @inline def keyStepper: LongStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[Long, HE](underlying)
     new StepsLongHashTableKey(tbl, 0, tbl.length)
@@ -176,7 +176,7 @@ extends AnyVal with MakesLongKeyStepper {
 // (both for key-value pair and for values alone)
 
 final class RichDefaultHashTableCanStep[K, V](private val underlying: collection.mutable.HashTable[K, collection.mutable.DefaultEntry[K, V]])
-extends AnyVal with MakesAnyStepper[(K, V)] {
+extends AnyVal with MakesStepper[AnyStepper[(K,V)] with EfficientSubstep] {
   @inline def stepper: AnyStepper[(K,V)] with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.DefaultEntry[K, V]](underlying)
     new StepsAnyDefaultHashTable(tbl, 0, tbl.length)
@@ -184,7 +184,7 @@ extends AnyVal with MakesAnyStepper[(K, V)] {
 }
 
 final class RichDefaultHashTableValueCanStep[K, V](private val underlying: collection.mutable.HashTable[K, collection.mutable.DefaultEntry[K, V]])
-extends AnyVal with MakesAnyValueStepper[V] {
+extends AnyVal with MakesValueStepper[AnyStepper[V] with EfficientSubstep] {
   @inline def valueStepper: AnyStepper[V] with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.DefaultEntry[K, V]](underlying)
     new StepsAnyDefaultHashTableValue(tbl, 0, tbl.length)
@@ -192,7 +192,7 @@ extends AnyVal with MakesAnyValueStepper[V] {
 }
 
 final class RichDefaultHashTableDoubleValueCanStep[K](private val underlying: collection.mutable.HashTable[K, collection.mutable.DefaultEntry[K, Double]])
-extends AnyVal with MakesDoubleValueStepper {
+extends AnyVal with MakesValueStepper[DoubleStepper with EfficientSubstep] {
   @inline def valueStepper: DoubleStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.DefaultEntry[K, Double]](underlying)
     new StepsDoubleDefaultHashTableValue(tbl, 0, tbl.length)
@@ -200,7 +200,7 @@ extends AnyVal with MakesDoubleValueStepper {
 }
 
 final class RichDefaultHashTableIntValueCanStep[K](private val underlying: collection.mutable.HashTable[K, collection.mutable.DefaultEntry[K, Int]])
-extends AnyVal with MakesIntValueStepper {
+extends AnyVal with MakesValueStepper[IntStepper with EfficientSubstep] {
   @inline def valueStepper: IntStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.DefaultEntry[K, Int]](underlying)
     new StepsIntDefaultHashTableValue(tbl, 0, tbl.length)
@@ -208,7 +208,7 @@ extends AnyVal with MakesIntValueStepper {
 }
 
 final class RichDefaultHashTableLongValueCanStep[K](private val underlying: collection.mutable.HashTable[K, collection.mutable.DefaultEntry[K, Long]])
-extends AnyVal with MakesLongValueStepper {
+extends AnyVal with MakesValueStepper[LongStepper with EfficientSubstep] {
   @inline def valueStepper: LongStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.DefaultEntry[K, Long]](underlying)
     new StepsLongDefaultHashTableValue(tbl, 0, tbl.length)
@@ -219,7 +219,7 @@ extends AnyVal with MakesLongValueStepper {
 // (both for key-value pair and for values alone)
 
 final class RichLinkedHashTableCanStep[K, V](private val underlying: collection.mutable.HashTable[K, collection.mutable.LinkedEntry[K, V]])
-extends AnyVal with MakesAnyStepper[(K,V)] {
+extends AnyVal with MakesStepper[AnyStepper[(K,V)] with EfficientSubstep] {
   @inline def stepper: AnyStepper[(K,V)] with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.LinkedEntry[K, V]](underlying)
     new StepsAnyLinkedHashTable(tbl, 0, tbl.length)
@@ -227,7 +227,7 @@ extends AnyVal with MakesAnyStepper[(K,V)] {
 }
 
 final class RichLinkedHashTableValueCanStep[K, V](private val underlying: collection.mutable.HashTable[K, collection.mutable.LinkedEntry[K, V]])
-extends AnyVal with MakesAnyValueStepper[V] {
+extends AnyVal with MakesValueStepper[AnyStepper[V] with EfficientSubstep] {
   @inline def valueStepper: AnyStepper[V] with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.LinkedEntry[K, V]](underlying)
     new StepsAnyLinkedHashTableValue(tbl, 0, tbl.length)
@@ -235,7 +235,7 @@ extends AnyVal with MakesAnyValueStepper[V] {
 }
 
 final class RichLinkedHashTableDoubleValueCanStep[K](private val underlying: collection.mutable.HashTable[K, collection.mutable.LinkedEntry[K, Double]])
-extends AnyVal with MakesDoubleValueStepper {
+extends AnyVal with MakesValueStepper[DoubleStepper with EfficientSubstep] {
   @inline def valueStepper: DoubleStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.LinkedEntry[K, Double]](underlying)
     new StepsDoubleLinkedHashTableValue(tbl, 0, tbl.length)
@@ -243,7 +243,7 @@ extends AnyVal with MakesDoubleValueStepper {
 }
 
 final class RichLinkedHashTableIntValueCanStep[K](private val underlying: collection.mutable.HashTable[K, collection.mutable.LinkedEntry[K, Int]])
-extends AnyVal with MakesIntValueStepper {
+extends AnyVal with MakesValueStepper[IntStepper with EfficientSubstep] {
   @inline def valueStepper: IntStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.LinkedEntry[K, Int]](underlying)
     new StepsIntLinkedHashTableValue(tbl, 0, tbl.length)
@@ -251,7 +251,7 @@ extends AnyVal with MakesIntValueStepper {
 }
 
 final class RichLinkedHashTableLongValueCanStep[K](private val underlying: collection.mutable.HashTable[K, collection.mutable.LinkedEntry[K, Long]])
-extends AnyVal with MakesLongValueStepper {
+extends AnyVal with MakesValueStepper[LongStepper with EfficientSubstep] {
   @inline def valueStepper: LongStepper with EfficientSubstep = {
     val tbl = CollectionInternals.getTable[K, collection.mutable.LinkedEntry[K, Long]](underlying)
     new StepsLongLinkedHashTableValue(tbl, 0, tbl.length)

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsImmHashMap.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsImmHashMap.scala
@@ -126,33 +126,33 @@ extends StepsLongLikeImmHashMap[K, Long, StepsLongImmHashMapValue[K]](_underlyin
 //////////////////////////
 
 final class RichImmHashMapCanStep[K, V](private val underlying: collection.immutable.HashMap[K, V])
-extends AnyVal with MakesAnyStepper[(K, V)] with MakesAnyKeyStepper[K] with MakesAnyValueStepper[V] {
+extends AnyVal with MakesStepper[AnyStepper[(K, V)] with EfficientSubstep] with MakesKeyStepper[AnyStepper[K] with EfficientSubstep] with MakesValueStepper[AnyStepper[V] with EfficientSubstep] {
   @inline def stepper: AnyStepper[(K, V)] with EfficientSubstep = new StepsAnyImmHashMap[K, V](underlying, 0, underlying.size)
   @inline def keyStepper: AnyStepper[K] with EfficientSubstep = new StepsAnyImmHashMapKey[K, V](underlying, 0, underlying.size)
   @inline def valueStepper: AnyStepper[V] with EfficientSubstep = new StepsAnyImmHashMapValue[K, V](underlying, 0, underlying.size)
 }
 
-final class RichImmHashMapDoubleKeyCanStep[V](private val underlying: collection.immutable.HashMap[Double, V]) extends AnyVal with MakesDoubleKeyStepper {
+final class RichImmHashMapDoubleKeyCanStep[V](private val underlying: collection.immutable.HashMap[Double, V]) extends AnyVal with MakesKeyStepper[DoubleStepper with EfficientSubstep] {
   @inline def keyStepper: DoubleStepper with EfficientSubstep = new StepsDoubleImmHashMapKey[V](underlying, 0, underlying.size)
 }
 
-final class RichImmHashMapDoubleValueCanStep[K](private val underlying: collection.immutable.HashMap[K, Double]) extends AnyVal with MakesDoubleValueStepper {
+final class RichImmHashMapDoubleValueCanStep[K](private val underlying: collection.immutable.HashMap[K, Double]) extends AnyVal with MakesValueStepper[DoubleStepper with EfficientSubstep] {
   @inline def valueStepper: DoubleStepper with EfficientSubstep = new StepsDoubleImmHashMapValue[K](underlying, 0, underlying.size)
 }
   
-final class RichImmHashMapIntKeyCanStep[V](private val underlying: collection.immutable.HashMap[Int, V]) extends AnyVal with MakesIntKeyStepper {
+final class RichImmHashMapIntKeyCanStep[V](private val underlying: collection.immutable.HashMap[Int, V]) extends AnyVal with MakesKeyStepper[IntStepper with EfficientSubstep] {
   @inline def keyStepper: IntStepper with EfficientSubstep = new StepsIntImmHashMapKey[V](underlying, 0, underlying.size)
 }
 
-final class RichImmHashMapIntValueCanStep[K](private val underlying: collection.immutable.HashMap[K, Int]) extends AnyVal with MakesIntValueStepper {
+final class RichImmHashMapIntValueCanStep[K](private val underlying: collection.immutable.HashMap[K, Int]) extends AnyVal with MakesValueStepper[IntStepper with EfficientSubstep] {
   @inline def valueStepper: IntStepper with EfficientSubstep = new StepsIntImmHashMapValue[K](underlying, 0, underlying.size)
 }
   
-final class RichImmHashMapLongKeyCanStep[V](private val underlying: collection.immutable.HashMap[Long, V]) extends AnyVal with MakesLongKeyStepper {
+final class RichImmHashMapLongKeyCanStep[V](private val underlying: collection.immutable.HashMap[Long, V]) extends AnyVal with MakesKeyStepper[LongStepper with EfficientSubstep] {
   @inline def keyStepper: LongStepper with EfficientSubstep = new StepsLongImmHashMapKey[V](underlying, 0, underlying.size)
 }
 
-final class RichImmHashMapLongValueCanStep[K](private val underlying: collection.immutable.HashMap[K, Long]) extends AnyVal with MakesLongValueStepper {
+final class RichImmHashMapLongValueCanStep[K](private val underlying: collection.immutable.HashMap[K, Long]) extends AnyVal with MakesValueStepper[LongStepper with EfficientSubstep] {
   @inline def valueStepper: LongStepper with EfficientSubstep = new StepsLongImmHashMapValue[K](underlying, 0, underlying.size)
 }
   

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsImmHashSet.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsImmHashSet.scala
@@ -39,18 +39,18 @@ extends StepsLongLikeTrieIterator[StepsLongImmHashSet](_underlying, _N) {
 // Value class adapters //
 //////////////////////////
 
-final class RichImmHashSetCanStep[A](private val underlying: collection.immutable.HashSet[A]) extends AnyVal with MakesAnyStepper[A] {
+final class RichImmHashSetCanStep[A](private val underlying: collection.immutable.HashSet[A]) extends AnyVal with MakesStepper[AnyStepper[A] with EfficientSubstep] {
   @inline def stepper: AnyStepper[A] with EfficientSubstep = new StepsAnyImmHashSet(underlying.iterator, underlying.size)
 }
 
-final class RichDoubleHashSetCanStep(private val underlying: collection.immutable.HashSet[Double]) extends AnyVal with MakesDoubleStepper {
+final class RichDoubleHashSetCanStep(private val underlying: collection.immutable.HashSet[Double]) extends AnyVal with MakesStepper[DoubleStepper with EfficientSubstep] {
   @inline def stepper: DoubleStepper with EfficientSubstep = new StepsDoubleImmHashSet(underlying.iterator, underlying.size)
 }
 
-final class RichIntHashSetCanStep(private val underlying: collection.immutable.HashSet[Int]) extends AnyVal with MakesIntStepper {
+final class RichIntHashSetCanStep(private val underlying: collection.immutable.HashSet[Int]) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = new StepsIntImmHashSet(underlying.iterator, underlying.size)
 }
 
-final class RichLongHashSetCanStep(private val underlying: collection.immutable.HashSet[Long]) extends AnyVal with MakesLongStepper {
+final class RichLongHashSetCanStep(private val underlying: collection.immutable.HashSet[Long]) extends AnyVal with MakesStepper[LongStepper with EfficientSubstep] {
   @inline def stepper: LongStepper with EfficientSubstep = new StepsLongImmHashSet(underlying.iterator, underlying.size)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsIndexedSeq.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsIndexedSeq.scala
@@ -39,18 +39,18 @@ extends StepsLongLikeIndexed[StepsLongIndexedSeq[CC]](_i0, _iN) {
 // Value class adapters //
 //////////////////////////
 
-final class RichIndexedSeqCanStep[A](private val underlying: collection.IndexedSeqLike[A, _]) extends AnyVal with MakesAnyStepper[A] {
+final class RichIndexedSeqCanStep[A](private val underlying: collection.IndexedSeqLike[A, _]) extends AnyVal with MakesStepper[AnyStepper[A] with EfficientSubstep] {
   @inline def stepper: AnyStepper[A] with EfficientSubstep = new StepsAnyIndexedSeq[A](underlying, 0, underlying.length)
 }
 
-final class RichDoubleIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Double, _]](private val underlying: CC) extends AnyVal with MakesDoubleStepper {
+final class RichDoubleIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Double, _]](private val underlying: CC) extends AnyVal with MakesStepper[DoubleStepper with EfficientSubstep] {
   @inline def stepper: DoubleStepper with EfficientSubstep = new StepsDoubleIndexedSeq[CC](underlying, 0, underlying.length)
 }
 
-final class RichIntIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Int, _]](private val underlying: CC) extends AnyVal with MakesIntStepper {
+final class RichIntIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Int, _]](private val underlying: CC) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = new StepsIntIndexedSeq[CC](underlying, 0, underlying.length)
 }
 
-final class RichLongIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Long, _]](private val underlying: CC) extends AnyVal with MakesLongStepper {
+final class RichLongIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Long, _]](private val underlying: CC) extends AnyVal with MakesStepper[LongStepper with EfficientSubstep] {
   @inline def stepper: LongStepper with EfficientSubstep = new StepsLongIndexedSeq[CC](underlying, 0, underlying.length)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsIterable.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsIterable.scala
@@ -10,18 +10,18 @@ import Stepper._
 // Iterables just defer to iterator unless they can pattern match something better.
 // TODO: implement pattern matching!
 
-final class RichIterableCanStep[A](private val underlying: Iterable[A]) extends AnyVal with MakesAnySeqStepper[A] {
+final class RichIterableCanStep[A](private val underlying: Iterable[A]) extends AnyVal with MakesStepper[AnyStepper[A]] {
   @inline def stepper: AnyStepper[A] = new StepsAnyIterator[A](underlying.iterator)
 }
 
-final class RichDoubleIterableCanStep(private val underlying: Iterable[Double]) extends AnyVal with MakesDoubleSeqStepper {
+final class RichDoubleIterableCanStep(private val underlying: Iterable[Double]) extends AnyVal with MakesStepper[DoubleStepper] {
   @inline def stepper: DoubleStepper = new StepsDoubleIterator(underlying.iterator)
 }
 
-final class RichIntIterableCanStep(private val underlying: Iterable[Int]) extends AnyVal with MakesIntSeqStepper {
+final class RichIntIterableCanStep(private val underlying: Iterable[Int]) extends AnyVal with MakesStepper[IntStepper] {
   @inline def stepper: IntStepper = new StepsIntIterator(underlying.iterator)
 }
 
-final class RichLongIterableCanStep(private val underlying: Iterable[Long]) extends AnyVal with MakesLongSeqStepper {
+final class RichLongIterableCanStep(private val underlying: Iterable[Long]) extends AnyVal with MakesStepper[LongStepper] {
   @inline def stepper: LongStepper = new StepsLongIterator(underlying.iterator)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsIterator.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsIterator.scala
@@ -39,19 +39,19 @@ extends StepsLongLikeIterator[StepsLongIterator](_underlying) {
 // Value class adapters //
 //////////////////////////
 
-final class RichIteratorCanStep[A](private val underlying: Iterator[A]) extends AnyVal with MakesAnySeqStepper[A] {
+final class RichIteratorCanStep[A](private val underlying: Iterator[A]) extends AnyVal with MakesStepper[AnyStepper[A]] {
   @inline def stepper: AnyStepper[A] = new StepsAnyIterator[A](underlying)
 }
 
-final class RichDoubleIteratorCanStep(private val underlying: Iterator[Double]) extends AnyVal with MakesDoubleSeqStepper {
+final class RichDoubleIteratorCanStep(private val underlying: Iterator[Double]) extends AnyVal with MakesStepper[DoubleStepper] {
   @inline def stepper: DoubleStepper = new StepsDoubleIterator(underlying)
 }
 
-final class RichIntIteratorCanStep(private val underlying: Iterator[Int]) extends AnyVal with MakesIntSeqStepper {
+final class RichIntIteratorCanStep(private val underlying: Iterator[Int]) extends AnyVal with MakesStepper[IntStepper] {
   @inline def stepper: IntStepper = new StepsIntIterator(underlying)
 }
 
-final class RichLongIteratorCanStep(private val underlying: Iterator[Long]) extends AnyVal with MakesLongSeqStepper {
+final class RichLongIteratorCanStep(private val underlying: Iterator[Long]) extends AnyVal with MakesStepper[LongStepper] {
   @inline def stepper: LongStepper = new StepsLongIterator(underlying)
 }
 

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsLikeGapped.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsLikeGapped.scala
@@ -11,7 +11,9 @@ import Stepper._
   * is used as a signal to look for more entries in the array.  (This also
   * allows a subclass to traverse a sublist by updating `currentEntry`.)
   */
-private[java8] abstract class AbstractStepsLikeGapped[Sub >: Null, Semi <: Sub](protected val underlying: Array[AnyRef], protected var i0: Int, protected var iN: Int) {
+private[java8] abstract class AbstractStepsLikeGapped[Sub >: Null, Semi <: Sub](protected val underlying: Array[AnyRef], protected var i0: Int, protected var iN: Int)
+  extends EfficientSubstep {
+
   protected var currentEntry: AnyRef = null
   def semiclone(half: Int): Semi
   def characteristics(): Int = Ordered
@@ -37,7 +39,6 @@ private[java8] abstract class AbstractStepsLikeGapped[Sub >: Null, Semi <: Sub](
 private[java8] abstract class StepsLikeGapped[A, STA >: Null <: StepsLikeGapped[A, _]](_underlying: Array[AnyRef], _i0: Int, _iN: Int)
   extends AbstractStepsLikeGapped[AnyStepper[A], STA](_underlying, _i0, _iN)
   with AnyStepper[A]
-  with EfficientSubstep
 {}
 
 /** Abstracts the process of stepping through an incompletely filled array of `AnyRefs`
@@ -47,7 +48,6 @@ private[java8] abstract class StepsLikeGapped[A, STA >: Null <: StepsLikeGapped[
 private[java8] abstract class StepsDoubleLikeGapped[STD >: Null <: StepsDoubleLikeGapped[_]](_underlying: Array[AnyRef], _i0: Int, _iN: Int)
   extends AbstractStepsLikeGapped[DoubleStepper, STD](_underlying, _i0, _iN)
   with DoubleStepper
-  with EfficientSubstep
 {}
 
 /** Abstracts the process of stepping through an incompletely filled array of `AnyRefs`
@@ -57,7 +57,6 @@ private[java8] abstract class StepsDoubleLikeGapped[STD >: Null <: StepsDoubleLi
 private[java8] abstract class StepsIntLikeGapped[STI >: Null <: StepsIntLikeGapped[_]](_underlying: Array[AnyRef], _i0: Int, _iN: Int)
   extends AbstractStepsLikeGapped[IntStepper, STI](_underlying, _i0, _iN)
   with IntStepper
-  with EfficientSubstep
 {}
 
 /** Abstracts the process of stepping through an incompletely filled array of `AnyRefs`
@@ -67,5 +66,4 @@ private[java8] abstract class StepsIntLikeGapped[STI >: Null <: StepsIntLikeGapp
 private[java8] abstract class StepsLongLikeGapped[STL >: Null <: StepsLongLikeGapped[_]](_underlying: Array[AnyRef], _i0: Int, _iN: Int)
   extends AbstractStepsLikeGapped[LongStepper, STL](_underlying, _i0, _iN)
   with LongStepper 
-  with EfficientSubstep
 {}

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsLikeIndexed.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsLikeIndexed.scala
@@ -6,7 +6,9 @@ import scala.compat.java8.collectionImpl._
 import Stepper._
 
 /** Abstracts all the generic operations of stepping over an indexable collection */
-private[java8] abstract class AbstractStepsLikeIndexed[Sub >: Null, Semi <: Sub](protected var i0: Int, protected var iN: Int) {
+private[java8] abstract class AbstractStepsLikeIndexed[Sub >: Null, Semi <: Sub](protected var i0: Int, protected var iN: Int)
+  extends EfficientSubstep {
+
   def semiclone(half: Int): Semi
   def characteristics(): Int = Ordered + Sized + SubSized
   def estimateSize(): Long = iN - i0
@@ -26,26 +28,22 @@ private[java8] abstract class AbstractStepsLikeIndexed[Sub >: Null, Semi <: Sub]
 private[java8] abstract class StepsLikeIndexed[A, STA >: Null <: StepsLikeIndexed[A, _]](_i0: Int, _iN: Int)
   extends AbstractStepsLikeIndexed[AnyStepper[A], STA](_i0, _iN)
   with AnyStepper[A]
-  with EfficientSubstep
 {}
 
 /** Abstracts the operation of stepping over an indexable collection of Doubles */
 private[java8] abstract class StepsDoubleLikeIndexed[STD >: Null <: StepsDoubleLikeIndexed[_]](_i0: Int, _iN: Int)
   extends AbstractStepsLikeIndexed[DoubleStepper, STD](_i0, _iN)
   with DoubleStepper
-  with EfficientSubstep
 {}
 
 /** Abstracts the operation of stepping over an indexable collection of Ints */
 private[java8] abstract class StepsIntLikeIndexed[STI >: Null <: StepsIntLikeIndexed[_]](_i0: Int, _iN: Int)
   extends AbstractStepsLikeIndexed[IntStepper, STI](_i0, _iN)
   with IntStepper
-  with EfficientSubstep
 {}
 
 /** Abstracts the operation of stepping over an indexable collection of Longs */
 private[java8] abstract class StepsLongLikeIndexed[STL >: Null <: StepsLongLikeIndexed[_]](_i0: Int, _iN: Int)
   extends AbstractStepsLikeIndexed[LongStepper, STL](_i0, _iN)
   with LongStepper
-  with EfficientSubstep
 {}

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsLikeSliced.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsLikeSliced.scala
@@ -9,7 +9,9 @@ import Stepper._
   * `next` must update `i` but not `i0` so that later splitting steps can keep track of whether the
   * collection needs some sort of modification before transmission to the subclass.
   */
-private[java8] abstract class AbstractStepsLikeSliced[Coll, Sub >: Null, Semi <: Sub](protected var underlying: Coll, protected var i: Int, protected var iN: Int) {
+private[java8] abstract class AbstractStepsLikeSliced[Coll, Sub >: Null, Semi <: Sub](protected var underlying: Coll, protected var i: Int, protected var iN: Int)
+  extends EfficientSubstep {
+
   protected var i0: Int = i
   def semiclone(halfHint: Int): Semi  // Must really do all the work for both this and cloned collection!
   def characteristics(): Int = Ordered
@@ -21,26 +23,22 @@ private[java8] abstract class AbstractStepsLikeSliced[Coll, Sub >: Null, Semi <:
 private[java8] abstract class StepsLikeSliced[A, AA, STA >: Null <: StepsLikeSliced[A, AA, _]](_underlying: AA, _i0: Int, _iN: Int)
   extends AbstractStepsLikeSliced[AA, AnyStepper[A], STA](_underlying, _i0, _iN)
   with AnyStepper[A]
-  with EfficientSubstep
 {}
 
 /** Abstracts the operation of stepping over a collection of Doubles that can be efficiently sliced or otherwise subdivided */
 private[java8] abstract class StepsDoubleLikeSliced[AA, STA >: Null <: StepsDoubleLikeSliced[AA, STA]](_underlying: AA, _i0: Int, _iN: Int)
   extends AbstractStepsLikeSliced[AA, DoubleStepper, STA](_underlying, _i0, _iN)
   with DoubleStepper
-  with EfficientSubstep
 {}
 
 /** Abstracts the operation of stepping over a collection of Ints that can be efficiently sliced or otherwise subdivided */
 private[java8] abstract class StepsIntLikeSliced[AA, STA >: Null <: StepsIntLikeSliced[AA, STA]](_underlying: AA, _i0: Int, _iN: Int)
   extends AbstractStepsLikeSliced[AA, IntStepper, STA](_underlying, _i0, _iN)
   with IntStepper
-  with EfficientSubstep
 {}
 
 /** Abstracts the operation of stepping over a collection of Longs that can be efficiently sliced or otherwise subdivided */
 private[java8] abstract class StepsLongLikeSliced[AA, STA >: Null <: StepsLongLikeSliced[AA, STA]](_underlying: AA, _i0: Int, _iN: Int)
   extends AbstractStepsLikeSliced[AA, LongStepper, STA](_underlying, _i0, _iN)
   with LongStepper
-  with EfficientSubstep
 {}

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsLinearSeq.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsLinearSeq.scala
@@ -47,18 +47,18 @@ extends StepsLongWithTail[CC, StepsLongLinearSeq[CC]](_underlying, _maxN) {
 // Value class adapters //
 //////////////////////////
 
-final class RichLinearSeqCanStep[A, CC >: Null <: collection.LinearSeqLike[A, CC]](private val underlying: CC) extends AnyVal with MakesAnySeqStepper[A] {
+final class RichLinearSeqCanStep[A, CC >: Null <: collection.LinearSeqLike[A, CC]](private val underlying: CC) extends AnyVal with MakesStepper[AnyStepper[A]] {
   @inline def stepper: AnyStepper[A] = new StepsAnyLinearSeq[A, CC](underlying, Long.MaxValue)
 }
 
-final class RichDoubleLinearSeqCanStep[CC >: Null <: collection.LinearSeqLike[Double, CC]](private val underlying: CC) extends AnyVal with MakesDoubleSeqStepper {
+final class RichDoubleLinearSeqCanStep[CC >: Null <: collection.LinearSeqLike[Double, CC]](private val underlying: CC) extends AnyVal with MakesStepper[DoubleStepper] {
   @inline def stepper: DoubleStepper = new StepsDoubleLinearSeq[CC](underlying, Long.MaxValue)
 }
 
-final class RichIntLinearSeqCanStep[CC >: Null <: collection.LinearSeqLike[Int, CC]](private val underlying: CC) extends AnyVal with MakesIntSeqStepper {
+final class RichIntLinearSeqCanStep[CC >: Null <: collection.LinearSeqLike[Int, CC]](private val underlying: CC) extends AnyVal with MakesStepper[IntStepper] {
   @inline def stepper: IntStepper = new StepsIntLinearSeq[CC](underlying, Long.MaxValue)
 }
 
-final class RichLongLinearSeqCanStep[CC >: Null <: collection.LinearSeqLike[Long, CC]](private val underlying: CC) extends AnyVal with MakesLongSeqStepper {
+final class RichLongLinearSeqCanStep[CC >: Null <: collection.LinearSeqLike[Long, CC]](private val underlying: CC) extends AnyVal with MakesStepper[LongStepper] {
   @inline def stepper: LongStepper = new StepsLongLinearSeq[CC](underlying, Long.MaxValue)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsMap.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsMap.scala
@@ -10,32 +10,32 @@ import Stepper._
 // Generic maps defer to the iterator steppers if a more precise type cannot be found via pattern matching
 // TODO: implement pattern matching
 
-final class RichMapCanStep[K, V](private val underlying: collection.Map[K, V]) extends AnyVal with MakesAnyKeySeqStepper[K] with MakesAnyValueSeqStepper[V] {
+final class RichMapCanStep[K, V](private val underlying: collection.Map[K, V]) extends AnyVal with MakesKeyStepper[AnyStepper[K]] with MakesValueStepper[AnyStepper[V]] {
   // No generic stepper because RichIterableCanStep will get that anyway, and we don't pattern match here
   def keyStepper: AnyStepper[K] = new StepsAnyIterator[K](underlying.keysIterator)
   def valueStepper: AnyStepper[V] = new StepsAnyIterator[V](underlying.valuesIterator)
 }
 
-final class RichDoubleKeyMapCanStep[V](private val underlying: collection.Map[Double, V]) extends AnyVal with MakesDoubleKeySeqStepper {
+final class RichDoubleKeyMapCanStep[V](private val underlying: collection.Map[Double, V]) extends AnyVal with MakesKeyStepper[DoubleStepper] {
   def keyStepper: DoubleStepper = new StepsDoubleIterator(underlying.keysIterator)
 }
 
-final class RichDoubleValueMapCanStep[K](private val underlying: collection.Map[K, Double]) extends AnyVal with MakesDoubleValueSeqStepper {
+final class RichDoubleValueMapCanStep[K](private val underlying: collection.Map[K, Double]) extends AnyVal with MakesValueStepper[DoubleStepper] {
   def valueStepper: DoubleStepper = new StepsDoubleIterator(underlying.valuesIterator)
 }
 
-final class RichIntKeyMapCanStep[V](private val underlying: collection.Map[Int, V]) extends AnyVal with MakesIntKeySeqStepper {
+final class RichIntKeyMapCanStep[V](private val underlying: collection.Map[Int, V]) extends AnyVal with MakesKeyStepper[IntStepper] {
   def keyStepper: IntStepper = new StepsIntIterator(underlying.keysIterator)
 }
 
-final class RichIntValueMapCanStep[K](private val underlying: collection.Map[K, Int]) extends AnyVal with MakesIntValueSeqStepper {
+final class RichIntValueMapCanStep[K](private val underlying: collection.Map[K, Int]) extends AnyVal with MakesValueStepper[IntStepper] {
   def valueStepper: IntStepper = new StepsIntIterator(underlying.valuesIterator)
 }
 
-final class RichLongKeyMapCanStep[V](private val underlying: collection.Map[Long, V]) extends AnyVal with MakesLongKeySeqStepper {
+final class RichLongKeyMapCanStep[V](private val underlying: collection.Map[Long, V]) extends AnyVal with MakesKeyStepper[LongStepper] {
   def keyStepper: LongStepper = new StepsLongIterator(underlying.keysIterator)
 }
 
-final class RichLongValueMapCanStep[K](private val underlying: collection.Map[K, Long]) extends AnyVal with MakesLongValueSeqStepper {
+final class RichLongValueMapCanStep[K](private val underlying: collection.Map[K, Long]) extends AnyVal with MakesValueStepper[LongStepper] {
   def valueStepper: LongStepper = new StepsLongIterator(underlying.valuesIterator)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsRange.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsRange.scala
@@ -39,18 +39,18 @@ extends StepsLongLikeIndexed[StepsLongNumericRange](_i0, _iN) {
 // Value class adapters //
 //////////////////////////
 
-final class RichRangeCanStep(private val underlying: Range) extends AnyVal with MakesIntStepper {
+final class RichRangeCanStep(private val underlying: Range) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = new StepsIntRange(underlying, 0, underlying.length)
 }  
 
-final class RichNumericRangeCanStep[T](private val underlying: collection.immutable.NumericRange[T]) extends AnyVal with MakesAnyStepper[T] {
+final class RichNumericRangeCanStep[T](private val underlying: collection.immutable.NumericRange[T]) extends AnyVal with MakesStepper[AnyStepper[T] with EfficientSubstep] {
   @inline def stepper: AnyStepper[T] with EfficientSubstep = new StepsAnyNumericRange[T](underlying, 0, underlying.length)
 }
 
-final class RichIntNumericRangeCanStep(private val underlying: collection.immutable.NumericRange[Int]) extends AnyVal with MakesIntStepper {
+final class RichIntNumericRangeCanStep(private val underlying: collection.immutable.NumericRange[Int]) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = new StepsIntNumericRange(underlying, 0, underlying.length)
 }
 
-final class RichLongNumericRangeCanStep(private val underlying: collection.immutable.NumericRange[Long]) extends AnyVal with MakesLongStepper {
+final class RichLongNumericRangeCanStep(private val underlying: collection.immutable.NumericRange[Long]) extends AnyVal with MakesStepper[LongStepper with EfficientSubstep] {
   @inline def stepper: LongStepper with EfficientSubstep = new StepsLongNumericRange(underlying, 0, underlying.length)
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsString.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsString.scala
@@ -45,7 +45,7 @@ private[java8] class StepperStringCodePoint(underlying: String, var i0: Int, var
 // Value class adapter //
 /////////////////////////
 
-final class RichStringCanStep(private val underlying: String) extends AnyVal with MakesIntStepper {
+final class RichStringCanStep(private val underlying: String) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = charStepper
   @inline def charStepper: IntStepper with EfficientSubstep = new StepperStringChar(underlying, 0, underlying.length)
   @inline def codepointStepper: IntStepper with EfficientSubstep = new StepperStringCodePoint(underlying, 0, underlying.length)

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsString.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsString.scala
@@ -11,6 +11,12 @@ import Stepper._
 // Stepper implementation //
 ////////////////////////////
 
+private[java8] class StepperStringChar(underlying: String, _i0: Int, _iN: Int)
+  extends StepsIntLikeIndexed[StepperStringChar](_i0, _iN) {
+  def nextInt() = if (hasNext()) { val j = i0; i0 += 1; underlying.charAt(j) } else throwNSEE
+  def semiclone(half: Int) = new StepperStringChar(underlying, i0, half)
+}
+
 private[java8] class StepperStringCodePoint(underlying: String, var i0: Int, var iN: Int) extends IntStepper with EfficientSubstep {
   def characteristics() = NonNull
   def estimateSize = iN - i0
@@ -40,5 +46,7 @@ private[java8] class StepperStringCodePoint(underlying: String, var i0: Int, var
 /////////////////////////
 
 final class RichStringCanStep(private val underlying: String) extends AnyVal with MakesIntStepper {
-  @inline def stepper: IntStepper with EfficientSubstep = new StepperStringCodePoint(underlying, 0, underlying.length)
-}    
+  @inline def stepper: IntStepper with EfficientSubstep = charStepper
+  @inline def charStepper: IntStepper with EfficientSubstep = new StepperStringChar(underlying, 0, underlying.length)
+  @inline def codepointStepper: IntStepper with EfficientSubstep = new StepperStringCodePoint(underlying, 0, underlying.length)
+}

--- a/src/main/scala/scala/compat/java8/converterImpl/StepsVector.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepsVector.scala
@@ -134,18 +134,18 @@ with StepsVectorLike[Long] {
 // Value class adapters //
 //////////////////////////
 
-final class RichVectorCanStep[A](private val underlying: Vector[A]) extends AnyVal with MakesAnyStepper[A] {
+final class RichVectorCanStep[A](private val underlying: Vector[A]) extends AnyVal with MakesStepper[AnyStepper[A] with EfficientSubstep] {
   @inline def stepper: AnyStepper[A] with EfficientSubstep = new StepsAnyVector[A](underlying, 0, underlying.length)
 }
 
-final class RichDoubleVectorCanStep[A](private val underlying: Vector[Double]) extends AnyVal with MakesDoubleStepper {
+final class RichDoubleVectorCanStep[A](private val underlying: Vector[Double]) extends AnyVal with MakesStepper[DoubleStepper with EfficientSubstep] {
   @inline def stepper: DoubleStepper with EfficientSubstep = new StepsDoubleVector(underlying, 0, underlying.length)
 }
 
-final class RichIntVectorCanStep[A](private val underlying: Vector[Int]) extends AnyVal with MakesIntStepper {
+final class RichIntVectorCanStep[A](private val underlying: Vector[Int]) extends AnyVal with MakesStepper[IntStepper with EfficientSubstep] {
   @inline def stepper: IntStepper with EfficientSubstep = new StepsIntVector(underlying, 0, underlying.length)
 }
 
-final class RichLongVectorCanStep[A](private val underlying: Vector[Long]) extends AnyVal with MakesLongStepper {
+final class RichLongVectorCanStep[A](private val underlying: Vector[Long]) extends AnyVal with MakesStepper[LongStepper with EfficientSubstep] {
   @inline def stepper: LongStepper with EfficientSubstep = new StepsLongVector(underlying, 0, underlying.length)
 }

--- a/src/test/java/scala/compat/java8/StreamConvertersExampleTest.java
+++ b/src/test/java/scala/compat/java8/StreamConvertersExampleTest.java
@@ -5,7 +5,7 @@
 import org.junit.Test;
 
 import scala.collection.mutable.ArrayBuffer;
-import scala.compat.java8.ScalaStreaming;
+import scala.compat.java8.ScalaStreamSupport;
 
 
 public class StreamConvertersExampleTest {
@@ -14,7 +14,7 @@ public class StreamConvertersExampleTest {
     ArrayBuffer<String> ab = new ArrayBuffer<String>();
     ab.$plus$eq("salmon");
     ab.$plus$eq("herring");
-    assert( ScalaStreaming.from(ab).mapToInt(x -> x.length()).sum() == 13 );
+    assert( ScalaStreamSupport.stream(ab).mapToInt(x -> x.length()).sum() == 13 );
   }
 }
 

--- a/src/test/scala/scala/compat/java8/StepperTest.scala
+++ b/src/test/scala/scala/compat/java8/StepperTest.scala
@@ -21,7 +21,6 @@ class IncStepperA(private val size0: Long) extends NextStepper[Int] {
     i = sub.size0
     sub
   }
-  def typedPrecisely = this
 }
 
 class IncStepperB(private val size0: Long) extends TryStepper[Int] {
@@ -37,7 +36,6 @@ class IncStepperB(private val size0: Long) extends TryStepper[Int] {
     i = sub.size0
     sub
   }
-  def typedPrecisely = this
 }
 
 class IncSpliterator(private val size0: Long) extends Spliterator.OfInt {
@@ -67,7 +65,6 @@ class MappingStepper[@specialized (Double, Int, Long) A, @specialized(Double, In
     if (undersub == null) null
     else new MappingStepper(undersub, mapping)
   }
-  def typedPrecisely = this
   def spliterator: Spliterator[B] = new MappingSpliterator[A, B](underlying.spliterator, mapping)
 }
 
@@ -209,12 +206,6 @@ class StepperTest {
   def knownSizes() {
     sources.foreach{ case (i,s) => assertEquals(i.toLong, s.knownSize) }
     sources.foreach{ case (i,s) => if (i > 0) subs(0)(s)(x => { assertEquals(x.knownSize, 1L); 0 }, _ + _) }
-  }
-
-  @Test
-  def consistentPrecision() {
-    sources.foreach{ case (_,s) => assert(s eq s.typedPrecisely) }
-    sources.foreach{ case (_,s) => subs(0)(s)(x => { assert(x eq x.typedPrecisely); 0}, _ + _) }
   }
 
   @Test


### PR DESCRIPTION
This is a collection of changes from the discussion on #61 which I expect to be straight-forward. Compared to my earlier branch, I removed the commit that added the `T <: AnyRef` restriction to `StreamConverters`. This needs a better design to take widening conversions into account.

Review by @Ichoran 