### PR TITLE
Add support for Scala 2.12.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
 script:
   - admin/build.sh
 scala:
-  - 2.11.7
-  - 2.12.0-M3
+  - 2.11.8
+  - 2.12.0-M4
 jdk:
   - oraclejdk8
 notifications:

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -22,8 +22,4 @@ if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-if [ "$TRAVIS_SCALA_VERSION" == "2.12.0-M4" ]; then
-  extraSbtOpts="-Dnodocs=true"
-fi
-
-sbt $extraSbtOpts ++$TRAVIS_SCALA_VERSION "$publishVersion" clean update test publishLocal $extraTarget
+sbt ++$TRAVIS_SCALA_VERSION "$publishVersion" clean update test publishLocal $extraTarget

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -22,4 +22,8 @@ if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt ++$TRAVIS_SCALA_VERSION "$publishVersion" clean update test publishLocal $extraTarget
+if [ "$TRAVIS_SCALA_VERSION" == "2.12.0-M4" ]; then
+  extraSbtOpts="-Dnodocs=true"
+fi
+
+sbt $extraSbtOpts ++$TRAVIS_SCALA_VERSION "$publishVersion" clean update test publishLocal $extraTarget

--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -25,7 +25,7 @@ object Type {
 }
 
 object CodeGen {
-  def packaging = "package scala.compat.java8;"
+  def packaging = "package scala.runtime.java8;"
   case class arity(n: Int) {
     val ns = (1 to n).toList
 

--- a/src/test/java/scala/compat/java8/SpecializedTest.scala
+++ b/src/test/java/scala/compat/java8/SpecializedTest.scala
@@ -4,7 +4,7 @@
 package scala.compat.java8
 
 import org.junit.Test
-import scala.compat.java8.SpecializedTestSupport.IntIdentity
+import scala.runtime.java8.SpecializedTestSupport.IntIdentity
 
 class SpecializedTest {
   @Test def specializationWorks() {

--- a/src/test/java/scala/runtime/java8/BoxingTest.java
+++ b/src/test/java/scala/runtime/java8/BoxingTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package scala.compat.java8;
+package scala.runtime.java8;
 
 import org.junit.Test;
 

--- a/src/test/java/scala/runtime/java8/LambdaTest.java
+++ b/src/test/java/scala/runtime/java8/LambdaTest.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package scala.compat.java8;
+package scala.runtime.java8;
 
 import org.apache.commons.lang3.SerializationUtils;
 import scala.runtime.*;
 
 import static junit.framework.Assert.assertEquals;
-import static scala.compat.java8.JFunction.*;
-import static scala.compat.java8.TestAPI.*;
+import static scala.runtime.java8.JFunction.*;
+import static scala.runtime.java8.TestAPI.*;
 
 import org.junit.Test;
 
@@ -99,20 +99,23 @@ public class LambdaTest {
         acceptFunction22Unit(   proc((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22) -> {v1.toUpperCase(); return;}));
     }
 
+    /*
+    // The JFunctions in 2.12.0-M4 are not Serializable anymore
     @Test
     public void isSerializable() {
-        scala.compat.java8.JFunction0<String> f0 = () -> "foo";
+        scala.runtime.java8.JFunction0<String> f0 = () -> "foo";
         assertEquals("foo", SerializationUtils.clone(f0).apply());
 
-        scala.compat.java8.JFunction1<String, String> f1 = (a) -> a.toUpperCase();
+        scala.runtime.java8.JFunction1<String, String> f1 = (a) -> a.toUpperCase();
         assertEquals("FOO", SerializationUtils.clone(f1).apply("foo"));
 
-        scala.compat.java8.JFunction2<String, String, String> f2 = (a, b) -> a + b;
+        scala.runtime.java8.JFunction2<String, String, String> f2 = (a, b) -> a + b;
         assertEquals("foobar", SerializationUtils.clone(f2).apply("foo", "bar"));
 
-        scala.compat.java8.JFunction3<String, String, String, String> f3 = (a, b, c) -> a + b + c;
+        scala.runtime.java8.JFunction3<String, String, String, String> f3 = (a, b, c) -> a + b + c;
         assertEquals("foobarbaz", SerializationUtils.clone(f3).apply("foo", "bar", "baz"));
     }
+    */
 
     private static scala.concurrent.Future<Integer> futureExample(
         scala.concurrent.Future<String> future, scala.concurrent.ExecutionContext ec) {

--- a/src/test/java/scala/runtime/java8/SpecializedFactoryTest.java
+++ b/src/test/java/scala/runtime/java8/SpecializedFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package scala.compat.java8;
+package scala.runtime.java8;
 
 import org.junit.Test;
 import scala.runtime.BoxedUnit;

--- a/src/test/java/scala/runtime/java8/SpecializedTestSupport.java
+++ b/src/test/java/scala/runtime/java8/SpecializedTestSupport.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2012-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package scala.compat.java8;
+package scala.runtime.java8;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
- M4 has native support for the `JFunction` types that used to be in
  this project but they are in `scala.runtime.java8`, not
  `scala.compat.java8`, so we move them to the same location. This
  breaks compatibility with the previous release of scala-java8-compat
  but now allows cross-building between Scala 2.11 and 2.12.0-M4.
  Tests and test support code is also moved to the new package. When
  building on 2.11 we still generate our own JFunctions but on 2.12
  the native ones are used.

- JFunctions in 2.12.0-M4 are not `Serializable` (see
  https://github.com/scala/scala-dev/issues/129) so the test for that
  is disabled for the time being.

- There is currently no genjavadoc-plugin for M4, so we only build the
  docs on 2.11.