### PR TITLE
Unboxed Steppers for `WrappedArray`

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -14,18 +14,14 @@ Because the benchmarking is **very computationally expensive** it should be done
 
 1. Make sure your terminal has plenty of lines of scrollback.  (A couple thousand should do.)
 
-2. Run `sbt`
+2. Run `sbt "jmh:run -i 5 -wi 3 -f 5"`. Wait overnight.
 
-3. Enter `jmh:run -i 5 -wi 3 -f5`.  Wait overnight.
+3. Clip off the last set of lines from the terminal window starting before the line that contains `[info] # Run complete. Total time:` and including that line until the end.
 
-4. Clip off the last set of lines from the terminal window starting before the line that contains `[info] # Run complete. Total time:` and including that line until the end.
-
-5. Save that in the file `results/jmhbench.log`
+4. Save that in the file `results/jmhbench.log`
 
 ## Comparison step
 
-1. Run `sbt console`
+1. Run `sbt parseJmh`
 
-2. Enter `bench.examine.SpeedReports()`
-
-3. Look at the ASCII art results showing speed comparisons.
+2. Look at the ASCII art results showing speed comparisons.

--- a/benchmark/build.sbt
+++ b/benchmark/build.sbt
@@ -1,6 +1,7 @@
 enablePlugins(JmhPlugin)
 
 val generateJmh = TaskKey[Unit]("generateJmh", "Generates JMH benchmark sources.")
+val parseJmh = TaskKey[Unit]("parseJmh", "Parses JMH benchmark logs in results/jmhbench.log.")
 
 lazy val root = (project in file(".")).settings(
   name := "java8-compat-bench",
@@ -11,5 +12,6 @@ lazy val root = (project in file(".")).settings(
   unmanagedJars in Compile ++= Seq(baseDirectory.value / "../target/scala-2.11/scala-java8-compat_2.11-0.8.0-SNAPSHOT.jar"),
   // This would be nicer but sbt-jmh doesn't like it:
   //unmanagedClasspath in Compile += Attributed.blank(baseDirectory.value / "../target/scala-2.11/classes"),
-  generateJmh := (runMain in Compile).toTask(" bench.codegen.GenJmhBench").value
+  generateJmh := (runMain in Compile).toTask(" bench.codegen.GenJmhBench").value,
+  parseJmh := (runMain in Compile).toTask(" bench.examine.ParseJmhLog").value
 )

--- a/benchmark/src/main/scala/bench/Operations.scala
+++ b/benchmark/src/main/scala/bench/Operations.scala
@@ -27,7 +27,13 @@ object OnInt {
   def sum(t: Traversable[Int]): Int = t.sum
   def sum(i: Iterator[Int]): Int = i.sum
   def sum(s: IntStepper): Int = s.fold(0)(_ + _)
-  def sum(s: IntStream): Int = s.sum
+  def sum(s: IntStream): Int = {
+    s.sum
+    /*var r = 0
+    val it = s.iterator()
+    while(it.hasNext) r += it.nextInt()
+    r*/
+  }
   def psum(i: ParIterable[Int]): Int = i.sum
   def psum(s: IntStream): Int = s.sum
 

--- a/benchmark/src/main/scala/bench/ParseJmhLog.scala
+++ b/benchmark/src/main/scala/bench/ParseJmhLog.scala
@@ -143,4 +143,6 @@ object ParseJmhLog {
     println("-"*79)
     println
   }
+
+  def main(args: Array[String]): Unit = apply()
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala
@@ -84,6 +84,13 @@ trait Priority2StepConverters extends Priority3StepConverters {
   implicit def richArrayCharCanStep(underlying: Array[Char]) = new RichArrayCharCanStep(underlying)
   implicit def richArrayShortCanStep(underlying: Array[Short]) = new RichArrayShortCanStep(underlying)
   implicit def richArrayFloatCanStep(underlying: Array[Float]) = new RichArrayFloatCanStep(underlying)
+
+  // No special cases for AnyStepper-producing WrappedArrays; they are treated as IndexedSeqs
+  implicit def richWrappedArrayByteCanStep(underlying: collection.mutable.WrappedArray[Byte]) = new RichArrayByteCanStep(underlying.array)
+  implicit def richWrappedArrayCharCanStep(underlying: collection.mutable.WrappedArray[Char]) = new RichArrayCharCanStep(underlying.array)
+  implicit def richWrappedArrayShortCanStep(underlying: collection.mutable.WrappedArray[Short]) = new RichArrayShortCanStep(underlying.array)
+  implicit def richWrappedArrayFloatCanStep(underlying: collection.mutable.WrappedArray[Float]) = new RichArrayFloatCanStep(underlying.array)
+
   implicit def richDoubleIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Double, _]](underlying: CC) =
     new RichDoubleIndexedSeqCanStep[CC](underlying)
   implicit def richIntIndexedSeqCanStep[CC <: collection.IndexedSeqLike[Int, _]](underlying: CC) =
@@ -113,7 +120,11 @@ trait Priority1StepConverters extends Priority2StepConverters {
   implicit def richArrayDoubleCanStep(underlying: Array[Double]) = new RichArrayDoubleCanStep(underlying)
   implicit def richArrayIntCanStep(underlying: Array[Int]) = new RichArrayIntCanStep(underlying)
   implicit def richArrayLongCanStep(underlying: Array[Long]) = new RichArrayLongCanStep(underlying)
-  
+
+  implicit def richWrappedArrayDoubleCanStep(underlying: collection.mutable.WrappedArray[Double]) = new RichArrayDoubleCanStep(underlying.array)
+  implicit def richWrappedArrayIntCanStep(underlying: collection.mutable.WrappedArray[Int]) = new RichArrayIntCanStep(underlying.array)
+  implicit def richWrappedArrayLongCanStep(underlying: collection.mutable.WrappedArray[Long]) = new RichArrayLongCanStep(underlying.array)
+
   implicit def richIntNumericRangeCanStep(underlying: collection.immutable.NumericRange[Int]) = new RichIntNumericRangeCanStep(underlying)
   implicit def richLongNumericRangeCanStep(underlying: collection.immutable.NumericRange[Long]) = new RichLongNumericRangeCanStep(underlying)
   implicit def richRangeCanStep(underlying: Range) = new RichRangeCanStep(underlying)

--- a/src/test/scala/scala/compat/java8/StreamConvertersTest.scala
+++ b/src/test/scala/scala/compat/java8/StreamConvertersTest.scala
@@ -3,10 +3,13 @@ package scala.compat.java8
 import org.junit.Test
 import org.junit.Assert._
 
+import java.util.stream._
+import StreamConverters._
+import scala.compat.java8.collectionImpl.IntStepper
+import scala.compat.java8.converterImpl.{MakesStepper, MakesSequentialStream}
+
 class StreamConvertersTest {
-  import java.util.stream._
-  import StreamConverters._
-  
+
   def assertEq[A](a1: A, a2: A, s: String) { assertEquals(s, a1, a2) }  // Weird order normally!
   def assertEq[A](a1: A, a2: A) { assertEq(a1, a2, "not equal") }
   
@@ -246,5 +249,14 @@ class StreamConvertersTest {
     assertEquals(Vector[Int](1, 2, 3), (Vector[Int](1, 2, 3).seqStream: IntStream).toScala[Vector])
     assertEquals(Vector[Short](1.toShort, 2.toShort, 3.toShort), (Vector[Short](1.toShort, 2.toShort, 3.toShort).seqStream: IntStream).toScala[Vector])
     assertEquals(Vector[String]("a", "b"), (Vector[String]("a", "b").seqStream: Stream[String]).toScala[Vector])
+  }
+
+  @Test
+  def streamMaterialization(): Unit = {
+    val coll = collection.mutable.WrappedArray.make[Int](Array(1,2,3))
+    val streamize = implicitly[collection.mutable.WrappedArray[Int] => MakesSequentialStream[java.lang.Integer, IntStream]]
+    assertTrue(streamize(coll).getClass.getName.contains("EnrichScalaCollectionWithSeqIntStream"))
+    val steppize = implicitly[collection.mutable.WrappedArray[Int] => MakesStepper[IntStepper]]
+    assertTrue(steppize(coll).getClass.getName.contains("RichArrayIntCanStep"))
   }
 }


### PR DESCRIPTION
- `WrappedArray` now produces the same primitive, non-boxing `Stepper`
  that the underlying `Array` would.

- Plus some improvements to the unit tests and benchmarks.

An interesting observation from the benchmarks: `IntStream.sum` is
horribly slow when used on a seqStream built from an `IntStepper`. It
is still slow when used on a seqStream built directly from an `Array`
with Java’s own stream support. Using a `while` loop on an `IntIterator`
produced by the stream beats both hands down and has the same
performance independent of the stream source.


More food for thought regarding Steppers vs Streams: There's currently no really nice way of getting a native Java array stream from a WrappedArray Stepper. We'd have to special case WrappedArray at both levels.