### PR TITLE
StreamConverters: correct typo in ScalaDoc

### DIFF
--- a/src/main/scala/scala/compat/java8/StreamConverters.scala
+++ b/src/main/scala/scala/compat/java8/StreamConverters.scala
@@ -159,7 +159,7 @@ trait Priority1StreamConverters extends Priority2StreamConverters {
   *
   * Examples:
   * {{{
-  * import scala.compat.java8.StreamConverers._
+  * import scala.compat.java8.StreamConverters._
   *
   * val s = Vector(1,2,3,4).parStream    // Stream[Int]
   * val si = s.unboxed                   // Stream.OfInt


### PR DESCRIPTION
StreamConverers -> StreamConverters