### PR TITLE
Upate scala-module-plugin, updates to tag-based publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 sudo: false
 env:
   global:
-    - PUBLISH_JDK=oraclejdk8
     # PGP_PASSPHRASE
     - secure: "BzgzRZLYa52rS/hBfzf43b++CfDhdcd3Mmu8tsyBHgThSQOd2YBLbV5kWD8aYVFKVHfW7XX0PTe3F+rR/fFZqGItE6o8Px0Y7Vzb5pqjlaQdxFEJ+WrsnshS0xuAKZ7OwVHRp+d+jznaCwRxEo2vpW3ko1OPAJ8cxfhVL/4C1I0="
     # SONA_USER
@@ -11,9 +10,6 @@ env:
     - secure: "FZC+FZnBNeklA150vW5QDZJ5J7t+DExJrgyXWM46Wh0MobjH8cvydgC3qatItb0rDBV8l7zO1LDwl2KEi92aefw2a8E49z6qVOHgUXiI3SAx7M0UO0FFeKPmTXCLcBlbnGLcUqNjIZfuIEufQvPblKTl8qN4eMmcMn9jsNzJr28="
 script:
   - admin/build.sh
-scala:
-  - 2.11.8
-  - 2.12.0
 jdk:
   - oraclejdk8
 notifications:

--- a/admin/README.md
+++ b/admin/README.md
@@ -12,49 +12,61 @@ To configure tag driven releases from Travis CI.
 
   1. Generate a key pair for this repository with `./admin/genKeyPair.sh`.
      Edit `.travis.yml` and `admin/build.sh` as prompted.
-  2. Publish the public key to https://pgp.mit.edu
-  3. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
+  1. Publish the public key to https://pgp.mit.edu
+  1. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
      Edit `.travis.yml` as prompted.
-  4. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
+  1. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  5. Edit `.travis.yml` to select which JDK will be used for publishing.
+  1. Edit `build.sbt`'s `scalaVersionsByJvm in ThisBuild` to select Scala and JVM version
+     combinations that will be used for publishing.
 
-It is important to add comments in .travis.yml to identify the name
+It is important to add comments in `.travis.yml` to identify the name
 of each environment variable encoded in a `:secure` section.
 
-After all of these steps, your .travis.yml should contain config of the
-form:
+After these steps, your `.travis.yml` should contain config of the form:
 
-	language: scala
-	env:
-	  global:
-	    - PUBLISH_JDK=openjdk6
-	    # PGP_PASSPHRASE
-	    - secure: "XXXXXX"
-	    # SONA_USER
-	    - secure: "XXXXXX"
-	    # SONA_PASS
-	    - secure: "XXXXXX"
-	script:
-	  - admin/build.sh
+```
+language: scala
+
+env:
+  global:
+    # PGP_PASSPHRASE
+    - secure: "XXXXXX"
+    # SONA_USER
+    - secure: "XXXXXX"
+    # SONA_PASS
+    - secure: "XXXXXX"
+
+script: admin/build.sh
+
+jdk:
+  - openjdk6
+  - oraclejdk8
+
+notifications:
+  email:
+    - a@b.com
+```
 
 If Sonatype credentials change in the future, step 3 can be repeated
 without generating a new key.
 
-Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/issues/1430)!
-
 ### Testing
 
-  1. Follow the release process below to create a dummy release (e.g. 0.1.0-TEST1).
+  1. Follow the release process below to create a dummy release (e.g., `v0.1.0-TEST1`).
      Confirm that the release was staged to Sonatype but do not release it to Maven
      central. Instead, drop the staging repository.
 
 ### Performing a release
 
-  1. Create a GitHub "Release" (with a corresponding tag) via the GitHub
+  1. Create a GitHub "Release" with a corresponding tag (e.g., `v0.1.1`) via the GitHub
      web interface.
-  2. Travis CI will schedule a build for this release. Review the build logs.
-  3. Log into https://oss.sonatype.org/ and identify the staging repository.
-  4. Sanity check its contents
-  5. Release staging repository to Maven and send out release announcement.
-
+  1. The release will be published using the Scala and JVM version combinations specified
+     in `scalaVersionsByJvm` in `build.sbt`.
+     - If you need to release against a different Scala version, include the Scala version
+       and the JVM version to use in the tag name, separated by `#`s (e.g., `v0.1.1#2.13.0-M1#8`).
+       Note that the JVM version needs to be listed in `.travis.yml` for the build to run.
+  1. Travis CI will schedule a build for this release. Review the build logs.
+  1. Log into https://oss.sonatype.org/ and identify the staging repository.
+  1. Sanity check its contents.
+  1. Release staging repository to Maven and send out release announcement.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -2,16 +2,44 @@
 
 set -e
 
-# prep environment for publish to sonatype staging if the HEAD commit is tagged
+# Builds of tagged revisions are published to sonatype staging.
 
-# git on travis does not fetch tags, but we have TRAVIS_TAG
-# headTag=$(git describe --exact-match ||:)
+# Travis runs a build on new revisions and on new tags, so a tagged revision is built twice.
+# Builds for a tag have TRAVIS_TAG defined, which we use for identifying tagged builds.
+# Checking the local git clone would not work because git on travis does not fetch tags.
 
-if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
-  echo "Going to release from tag $TRAVIS_TAG!"
-  myVer=$(echo $TRAVIS_TAG | sed -e s/^v// | sed -e 's/_[0-9]*\.[0-9]*//')
-  publishVersion='set every version := "'$myVer'"'
-  extraTarget="publish-signed"
+# The version number to be published is extracted from the tag, e.g., v1.2.3 publishes
+# version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
+
+# When a new, binary incompatible Scala version becomes available, a previously released version
+# can be released using that new Scala version by creating a new tag containing the Scala and the
+# JVM version after hashes, e.g., v1.2.3#2.13.0-M1#8. The JVM version needs to be listed in
+# `.travis.yml`, otherwise the required build doesn't run.
+
+verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
+tagPat="^v$verPat(#$verPat#[0-9]+)?$"
+
+if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
+  currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
+
+  tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
+  publishVersion='set every version := "'$tagVer'"'
+
+  scalaAndJvmVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
+  if [ "$scalaAndJvmVer" != "" ]; then
+    scalaVer=$(echo $scalaAndJvmVer | sed s/#.*//)
+    jvmVer=$(echo $scalaAndJvmVer | sed s/[^#]*// | sed s/^#//)
+    if [ "$jvmVer" != "$currentJvmVer" ]; then
+      echo "Not publishing $TRAVIS_TAG on Java version $currentJvmVer."
+      exit 0
+    fi
+    publishScalaVersion='set every ScalaModulePlugin.scalaVersionsByJvm := Map('$jvmVer' -> List("'$scalaVer'" -> true))'
+    echo "Releasing $tagVer using Scala $scalaVer on Java version $jvmVer."
+  else
+    echo "Releasing $tagVer on Java version $currentJvmVer according to 'scalaVersionsByJvm' in build.sbt."
+  fi
+
+  extraTarget="+publish-signed"
   cat admin/gpg.sbt >> project/plugins.sbt
   cp admin/publish-settings.sbt .
 
@@ -22,4 +50,4 @@ if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt ++$TRAVIS_SCALA_VERSION "$publishVersion" clean update test publishLocal $extraTarget
+sbt "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ScalaModulePlugin._
 
 scalaVersionsByJvm in ThisBuild := Map(
-  8 -> List("2.12.0", "2.11.8").map(_ -> true)
+  8 -> List("2.12.0", "2.11.8", "2.13.0-M1").map(_ -> true)
 )
 
 val disableDocs = sys.props("nodocs") == "true"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,9 @@
+import ScalaModulePlugin._
+
+scalaVersionsByJvm in ThisBuild := Map(
+  8 -> List("2.12.0", "2.11.8").map(_ -> true)
+)
+
 val disableDocs = sys.props("nodocs") == "true"
 
 lazy val JavaDoc = config("genjavadoc") extend Compile
@@ -16,8 +22,6 @@ def osgiExport(scalaVersion: String, version: String) = {
 }
 
 lazy val commonSettings = Seq(
-  crossScalaVersions := List("2.12.0", "2.11.8"),
-  scalaVersion := crossScalaVersions.value.head,
   organization := "org.scala-lang.modules",
   version := "0.9.0-SNAPSHOT"
 )
@@ -35,10 +39,6 @@ lazy val root = (project in file(".")).
   settings(commonSettings: _*).
   settings(
     name := "scala-java8-compat"
-  ).
-  settings(
-    // important!! must come here (why?)
-    scalaModuleOsgiSettings: _*
   ).
   settings(
     fork := true, // This must be set so that runner task is forked when it runs fnGen and the compiler gets a proper classpath

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.3")
+addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")


### PR DESCRIPTION
After this patch, `.travis.yml` no longer defines any Scala versions,
this is always done in sbt. This way there's a single place to update
Scala versions.