### PR TITLE
Scala 2.13.0-M2, plus other version bumps

### DIFF
--- a/benchmark/build.sbt
+++ b/benchmark/build.sbt
@@ -5,8 +5,8 @@ val parseJmh = TaskKey[Unit]("parseJmh", "Parses JMH benchmark logs in results/j
 
 lazy val root = (project in file(".")).settings(
   name := "java8-compat-bench",
-  scalaVersion := "2.11.8",
-  crossScalaVersions := List("2.11.8" /* TODO, "2.12.0-M4"*/),
+  scalaVersion := "2.11.11",
+  crossScalaVersions := List("2.11.11" /* TODO, "2.12.0-M4"*/),
   organization := "org.scala-lang.modules",
   version := "0.6.0-SNAPSHOT",
   unmanagedJars in Compile ++= Seq(baseDirectory.value / "../target/scala-2.11/scala-java8-compat_2.11-0.9.0-SNAPSHOT.jar"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ScalaModulePlugin._
 
 scalaVersionsByJvm in ThisBuild := Map(
-  8 -> List("2.12.2", "2.11.11", "2.13.0-M1").map(_ -> true)
+  8 -> List("2.12.3", "2.11.11", "2.13.0-M2").map(_ -> true)
 )
 
 val disableDocs = sys.props("nodocs") == "true"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 scalacOptions += "-Xfatal-warnings"
 
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")


### PR DESCRIPTION
2.11.8->11, 2.12.0->3, sbt 0.13.15->16, sbt-scala-module 1.0.8 -> 1.0.12

upgrade all the things. the past is past. the future is glorious.