### PR TITLE
Remove override of `Future.onSuccess`

### DIFF
--- a/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
+++ b/src/main/scala/scala/concurrent/java8/FutureConvertersImpl.scala
@@ -87,8 +87,6 @@ object FuturesConvertersImpl {
   }
 
   class P[T](val wrapped: CompletionStage[T]) extends DefaultPromise[T] with BiConsumer[T, Throwable] {
-    override def onSuccess[U](pf: PartialFunction[T, U])(implicit executor: ExecutionContext): Unit = super.onSuccess(pf)
-
     override def accept(v: T, e: Throwable): Unit = {
       if (e == null) complete(Success(v))
       else complete(Failure(e))


### PR DESCRIPTION
`Future.onSuccess` is deprecated and slated for removal. See also scala/scala#6319.

Fixes #99 