### PR TITLE
preparing for 0.9.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ jdk:
 notifications:
   email:
     - jason.zaugg@lightbend.com
+    - seth.tisue@lightbend.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## scala-java8-compat [<img src="https://img.shields.io/travis/scala/scala-java8-compat.svg"/>](https://travis-ci.org/scala/scala-java8-compat) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-java8-compat_2.11.svg?label=latest%20release%20for%202.11"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-java8-compat_2.11) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-java8-compat_2.12.svg?label=latest%20release%20for%202.12"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-java8-compat_2.12)
+## scala-java8-compat [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-java8-compat_2.11.svg?label=latest%20release%20for%202.11"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-java8-compat_2.11) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-java8-compat_2.12.svg?label=latest%20release%20for%202.12"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-java8-compat_2.12)
 
 A Java 8 compatibility kit for Scala.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 import ScalaModulePlugin._
 
 scalaVersionsByJvm in ThisBuild := {
-  val versions = List("2.12.4", "2.11.12", "2.13.0-M3").map(_ -> true)
+  // no 2.13 for now in cross-build because of
+  // https://github.com/scala/scala-java8-compat/issues/97
+  val versions = List("2.12.4", "2.11.12").map(_ -> true)
   Map(8 -> versions, 9 -> versions, 10 -> versions)
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ def osgiExport(scalaVersion: String, version: String) = {
 
 lazy val commonSettings = Seq(
   organization := "org.scala-lang.modules",
-  version := "0.9.0-SNAPSHOT",
+  version := "0.9.1-SNAPSHOT",
   scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 )
 

--- a/src/main/scala/scala/compat/java8/DurationConverters.scala
+++ b/src/main/scala/scala/compat/java8/DurationConverters.scala
@@ -64,14 +64,14 @@ object DurationConverters {
 
   implicit final class DurationOps(val duration: java.time.Duration) extends AnyVal {
     /**
-     * See [[DurationConverters.toScala]]
+     * See [[DurationConverters#toScala]]
      */
     def toScala: scala.concurrent.duration.FiniteDuration = DurationConverters.toScala(duration)
   }
 
   implicit final class FiniteDurationops(val duration: scala.concurrent.duration.FiniteDuration) extends AnyVal {
     /**
-     * See [[DurationConverters.toJava]]
+     * See [[DurationConverters#toJava]]
      */
     def toJava: java.time.Duration = DurationConverters.toJava(duration)
   }


### PR DESCRIPTION
leaving Scala at 2.12.4 for now because there isn't a genjavadoc
release for 2.12.6 yet