### PR TITLE
Simplify tag-driven releases, no longer use `scalaVersionsByJvm`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: scala
+
 sudo: false
+
+jdk:
+  - oraclejdk8
+
+scala:
+  # no 2.13 for now in cross-build because of
+  # https://github.com/scala/scala-java8-compat/issues/97
+  - 2.11.12
+  - 2.12.6
+
 env:
   global:
     # PGP_PASSPHRASE
@@ -8,10 +19,10 @@ env:
     - secure: "lx2qFeFxh9AFmyHR7hH4Qf9flIEx8VgYj6ebzuxp1cc1ZZiXHC1256x0bHFDUH9bhJACOazOrco/+v6MBAriBkWxLBc98FrC6OkVeQMFW2ffWSBuHRclilKsQA/Lsgc81Wg+WV105hOqUNAkTXgroblInNt+KS+DhC/8FVoh9ZY="
     # SONA_PASS
     - secure: "FZC+FZnBNeklA150vW5QDZJ5J7t+DExJrgyXWM46Wh0MobjH8cvydgC3qatItb0rDBV8l7zO1LDwl2KEi92aefw2a8E49z6qVOHgUXiI3SAx7M0UO0FFeKPmTXCLcBlbnGLcUqNjIZfuIEufQvPblKTl8qN4eMmcMn9jsNzJr28="
+
 script:
   - admin/build.sh
-jdk:
-  - oraclejdk8
+
 notifications:
   email:
     - jason.zaugg@lightbend.com

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,11 +1,5 @@
 ## Tag Driven Releasing
 
-### Background Reading
-
-  - http://docs.travis-ci.com/user/environment-variables/
-  - http://docs.travis-ci.com/user/encryption-keys/
-  - http://docs.travis-ci.com/user/encrypting-files/
-
 ### Initial setup for the repository
 
 To configure tag driven releases from Travis CI.
@@ -13,20 +7,28 @@ To configure tag driven releases from Travis CI.
   1. Generate a key pair for this repository with `./admin/genKeyPair.sh`.
      Edit `.travis.yml` and `admin/build.sh` as prompted.
   1. Publish the public key to https://pgp.mit.edu
-  1. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
+  1. Store other secrets as encrypted environment variables with `./admin/encryptEnvVars.sh`.
      Edit `.travis.yml` as prompted.
   1. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  1. Edit `build.sbt`'s `scalaVersionsByJvm in ThisBuild` to select Scala and JVM version
-     combinations that will be used for publishing.
+     Ensure that `RELEASE_COMBO` is `true` for build matrix combinations
+     that should be released to sonatype (when building a tag).
 
 It is important to add comments in `.travis.yml` to identify the name
-of each environment variable encoded in a `:secure` section.
+of each environment variable encoded in a `secure` section.
 
 After these steps, your `.travis.yml` should contain config of the form:
 
 ```
 language: scala
+
+jdk:
+  - openjdk6
+  - oraclejdk8
+
+scala:
+  - 2.11.12
+  - 2.12.6
 
 env:
   global:
@@ -38,10 +40,6 @@ env:
     - secure: "XXXXXX"
 
 script: admin/build.sh
-
-jdk:
-  - openjdk6
-  - oraclejdk8
 
 notifications:
   email:
@@ -62,10 +60,9 @@ without generating a new key.
   1. Create a GitHub "Release" with a corresponding tag (e.g., `v0.1.1`) via the GitHub
      web interface.
   1. The release will be published using the Scala and JVM version combinations specified
-     in `scalaVersionsByJvm` in `build.sbt`.
-     - If you need to release against a different Scala version, include the Scala version
-       and the JVM version to use in the tag name, separated by `#`s (e.g., `v0.1.1#2.13.0-M1#8`).
-       Note that the JVM version needs to be listed in `.travis.yml` for the build to run.
+     in the travis build matrix where `[ "$RELEASE_COMBO" = "true" ]`.
+     - If you need to release against a different Scala version, create a new commit that modifies
+       `.travis.yml` and push a new tag, e.g., `v1.2.3#2.13.0-M5`. The suffix after `#` is ignored.
   1. Travis CI will schedule a build for this release. Review the build logs.
   1. Log into https://oss.sonatype.org/ and identify the staging repository.
   1. Sanity check its contents.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -9,45 +9,36 @@ set -e
 # Checking the local git clone would not work because git on travis does not fetch tags.
 
 # The version number to be published is extracted from the tag, e.g., v1.2.3 publishes
-# version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
+# version 1.2.3 on all combinations of the travis matrix where `[ "$RELEASE_COMBO" = "true" ]`.
 
-# When a new, binary incompatible Scala version becomes available, a previously released version
-# can be released using that new Scala version by creating a new tag containing the Scala and the
-# JVM version after hashes, e.g., v1.2.3#2.13.0-M1#8. The JVM version needs to be listed in
-# `.travis.yml`, otherwise the required build doesn't run.
+# In order to build a previously released version against a new (binary incompatible) Scala release,
+# a new commit that modifies (and prunes) the Scala versions in .travis.yml needs to be added on top
+# of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
+# Everything after the `#` in the tag name is ignored.
+
+RELEASE_COMBO=true
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
-tagPat="^v$verPat(#$verPat#[0-9]+)?$"
+tagPat="^v$verPat(#.*)?$"
 
 if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
-  currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
-
   tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
   publishVersion='set every version := "'$tagVer'"'
 
-  scalaAndJvmVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
-  if [ "$scalaAndJvmVer" != "" ]; then
-    scalaVer=$(echo $scalaAndJvmVer | sed s/#.*//)
-    jvmVer=$(echo $scalaAndJvmVer | sed s/[^#]*// | sed s/^#//)
-    if [ "$jvmVer" != "$currentJvmVer" ]; then
-      echo "Not publishing $TRAVIS_TAG on Java version $currentJvmVer."
-      exit 0
-    fi
-    publishScalaVersion='set every ScalaModulePlugin.scalaVersionsByJvm := Map('$jvmVer' -> List("'$scalaVer'" -> true))'
-    echo "Releasing $tagVer using Scala $scalaVer on Java version $jvmVer."
-  else
-    echo "Releasing $tagVer on Java version $currentJvmVer according to 'scalaVersionsByJvm' in build.sbt."
+  if [ "$RELEASE_COMBO" = "true" ]; then
+    currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
+    echo "Releasing $tagVer with Scala $TRAVIS_SCALA_VERSION on Java version $currentJvmVer."
+
+    publishTask="publish-signed"
+
+    cat admin/gpg.sbt >> project/plugins.sbt
+    cp admin/publish-settings.sbt .
+
+    # Copied from the output of genKeyPair.sh
+    K=$encrypted_1ce132863fa7_key
+    IV=$encrypted_1ce132863fa7_iv
+    openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
   fi
-
-  extraTarget="+publish-signed"
-  cat admin/gpg.sbt >> project/plugins.sbt
-  cp admin/publish-settings.sbt .
-
-  # Copied from the output of genKeyPair.sh
-  K=$encrypted_1ce132863fa7_key
-  IV=$encrypted_1ce132863fa7_iv
-
-  openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget
+sbt "++$TRAVIS_SCALA_VERSION" "$publishVersion" clean test publishLocal "$publishTask"

--- a/admin/publish-settings.sbt
+++ b/admin/publish-settings.sbt
@@ -1,9 +1,8 @@
 def env(key: String) = Option(System.getenv(key)).getOrElse("")
 
-pgpPassphrase := Some(env("PGP_PASSPHRASE").toArray)
-
-pgpPublicRing := file("admin/pubring.asc")
-
-pgpSecretRing := file("admin/secring.asc")
-
-credentials   += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))
+inThisBuild(Seq(
+  pgpPassphrase := Some(env("PGP_PASSPHRASE").toArray),
+  pgpPublicRing := file("admin/pubring.asc"),
+  pgpSecretRing := file("admin/secring.asc"),
+  credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))
+))

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,8 @@
 import ScalaModulePlugin._
 
-scalaVersionsByJvm in ThisBuild := {
-  // no 2.13 for now in cross-build because of
-  // https://github.com/scala/scala-java8-compat/issues/97
-  val versions = List("2.12.6", "2.11.12").map(_ -> true)
-  Map(8 -> versions, 9 -> versions, 10 -> versions)
-}
+// no 2.13 for now in cross-build because of
+// https://github.com/scala/scala-java8-compat/issues/97
+crossScalaVersions in ThisBuild := List("2.12.6", "2.11.12")
 
 val disableDocs = sys.props("nodocs") == "true"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 scalacOptions += "-Xfatal-warnings"
 
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.13")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")


### PR DESCRIPTION
This brings the scripts in line with scala-xml, scala-collection-compat,
and we're doing the same for other modules