### PR TITLE
fix compile errors in latest Scala 2.13

### DIFF
--- a/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala
@@ -1,6 +1,8 @@
-package scala.compat.java8.converterImpl
+package scala.compat.java8
+package converterImpl
 
 import language.implicitConversions
+import scala.reflect.ClassTag
 
 trait Priority3StepConverters {
   implicit def richIterableCanStep[A](underlying: Iterable[A]) = new RichIterableCanStep(underlying)
@@ -16,7 +18,7 @@ trait Priority1StepConverters extends Priority2StepConverters {
   implicit def richDefaultHashMapCanStep[K, V](underlying: collection.mutable.HashMap[K, V]) = new RichHashMapCanStep[K, V](underlying)
   implicit def richLinkedHashMapCanStep[K, V](underlying: collection.mutable.LinkedHashMap[K, V]) = new RichLinkedHashMapCanStep[K, V](underlying)
   implicit def richArrayCanStep[A](underlying: Array[A]) = new RichArrayCanStep[A](underlying)
-  implicit def richArraySeqCanStep[A](underlying: collection.mutable.ArraySeq[A]) = new RichArrayCanStep[A](underlying.array)
+  implicit def richArraySeqCanStep[A: ClassTag](underlying: collection.mutable.ArraySeq[A]) = new RichArrayCanStep[A](StreamConverters.unsafeArrayIfPossible(underlying))
   implicit def richHashSetCanStep[A](underlying: collection.mutable.HashSet[A]) = new RichHashSetCanStep[A](underlying)
   implicit def richIteratorCanStep[A](underlying: Iterator[A]) = new RichIteratorCanStep(underlying)
   implicit def richImmHashMapCanStep[K, V](underlying: collection.immutable.HashMap[K, V]) = new RichImmHashMapCanStep[K, V](underlying)


### PR DESCRIPTION
fix https://github.com/scala/scala-java8-compat/issues/110

- https://github.com/scala/scala/commit/1e21c918361b22d66575acb82b57d532823b198a#diff-c4d00ae1df2a449ae3d28a7a4469e28a
- https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1187/consoleFull

```
[scala-java8-compat] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/scala-java8-compat-e21fca9479a0769dd077af3a1d088d2f68798316/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala:19: type mismatch;
[scala-java8-compat] [error]  found   : Array[_$2] where type _$2
[scala-java8-compat] [error]  required: Array[A]
[scala-java8-compat] [error]  Note: implicit method richArraySeqCanStep is not applicable here because it comes after the application point and it lacks an explicit result type
[scala-java8-compat] [error]   implicit def richArraySeqCanStep[A](underlying: collection.mutable.ArraySeq[A]) = new RichArrayCanStep[A](underlying.array)
[scala-java8-compat] [error]                                                                                                                        ^
[scala-java8-compat] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/scala-java8-compat-e21fca9479a0769dd077af3a1d088d2f68798316/src/main/scala/scala/compat/java8/StreamConverters.scala:200: type mismatch;
[scala-java8-compat] [error]  found   : Array[_$2] where type _$2
[scala-java8-compat] [error]  required: Array[Double]
[scala-java8-compat] [error]  Note: implicit value accumulateLongStepper is not applicable here because it comes after the application point and it lacks an explicit result type
[scala-java8-compat] [error]     def seqStream: DoubleStream = java.util.Arrays.stream(a.array)
[scala-java8-compat] [error]                                                             ^
[scala-java8-compat] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/scala-java8-compat-e21fca9479a0769dd077af3a1d088d2f68798316/src/main/scala/scala/compat/java8/StreamConverters.scala:206: type mismatch;
[scala-java8-compat] [error]  found   : Array[_$2] where type _$2
[scala-java8-compat] [error]  required: Array[Int]
[scala-java8-compat] [error]  Note: implicit value accumulateLongStepper is not applicable here because it comes after the application point and it lacks an explicit result type
[scala-java8-compat] [error]     def seqStream: IntStream = java.util.Arrays.stream(a.array)
[scala-java8-compat] [error]                                                          ^
[scala-java8-compat] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/scala-java8-compat-e21fca9479a0769dd077af3a1d088d2f68798316/src/main/scala/scala/compat/java8/StreamConverters.scala:212: type mismatch;
[scala-java8-compat] [error]  found   : Array[_$2] where type _$2
[scala-java8-compat] [error]  required: Array[Long]
[scala-java8-compat] [error]  Note: implicit value accumulateLongStepper is not applicable here because it comes after the application point and it lacks an explicit result type
[scala-java8-compat] [error]     def seqStream: LongStream = java.util.Arrays.stream(a.array)
[scala-java8-compat] [error]                                                           ^
```