### PR TITLE
adapt to post 2.13.0-M4 changes

### DIFF
--- a/src/main/scala/scala/compat/java8/StreamConverters.scala
+++ b/src/main/scala/scala/compat/java8/StreamConverters.scala
@@ -221,52 +221,58 @@ with converterImpl.Priority1AccumulatorConverters
     def parStream: LongStream = seqStream.parallel
   }
 
-  implicit val primitiveAccumulateDoubleStream = new PrimitiveStreamAccumulator[Stream[Double], DoubleAccumulator] {
-    def streamAccumulate(stream: Stream[Double]): DoubleAccumulator = 
-      stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.boxedAdder, DoubleAccumulator.merger)
-  }
-  
-  implicit val primitiveAccumulateDoubleStream2 =
+  implicit val primitiveAccumulateDoubleStream: PrimitiveStreamAccumulator[Stream[Double], DoubleAccumulator] =
+    new PrimitiveStreamAccumulator[Stream[Double], DoubleAccumulator] {
+      def streamAccumulate(stream: Stream[Double]): DoubleAccumulator =
+        stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.boxedAdder, DoubleAccumulator.merger)
+    }
+
+  implicit val primitiveAccumulateDoubleStream2: PrimitiveStreamAccumulator[Stream[java.lang.Double], DoubleAccumulator] =
     primitiveAccumulateDoubleStream.asInstanceOf[PrimitiveStreamAccumulator[Stream[java.lang.Double], DoubleAccumulator]]
-    
-  implicit val primitiveUnboxDoubleStream = new PrimitiveStreamUnboxer[Double, DoubleStream] {
-    def apply(boxed: Stream[Double]): DoubleStream = 
-      boxed.mapToDouble(new java.util.function.ToDoubleFunction[Double]{ def applyAsDouble(d: Double) = d })
-  }
-  
-  implicit val primitiveUnboxDoubleStream2 =
+
+  implicit val primitiveUnboxDoubleStream: PrimitiveStreamUnboxer[Double, DoubleStream] =
+    new PrimitiveStreamUnboxer[Double, DoubleStream] {
+      def apply(boxed: Stream[Double]): DoubleStream =
+        boxed.mapToDouble(new java.util.function.ToDoubleFunction[Double]{ def applyAsDouble(d: Double) = d })
+    }
+
+  implicit val primitiveUnboxDoubleStream2: PrimitiveStreamUnboxer[java.lang.Double, DoubleStream] =
     primitiveUnboxDoubleStream.asInstanceOf[PrimitiveStreamUnboxer[java.lang.Double, DoubleStream]]
-  
-  implicit val primitiveAccumulateIntStream = new PrimitiveStreamAccumulator[Stream[Int], IntAccumulator] { 
-    def streamAccumulate(stream: Stream[Int]): IntAccumulator = 
-      stream.collect(IntAccumulator.supplier, IntAccumulator.boxedAdder, IntAccumulator.merger)
-  }
 
-  implicit val primitiveAccumulateIntStream2 =
+  implicit val primitiveAccumulateIntStream: PrimitiveStreamAccumulator[Stream[Int], IntAccumulator] =
+    new PrimitiveStreamAccumulator[Stream[Int], IntAccumulator] {
+      def streamAccumulate(stream: Stream[Int]): IntAccumulator =
+        stream.collect(IntAccumulator.supplier, IntAccumulator.boxedAdder, IntAccumulator.merger)
+    }
+
+  implicit val primitiveAccumulateIntStream2: PrimitiveStreamAccumulator[Stream[java.lang.Integer], IntAccumulator] =
     primitiveAccumulateIntStream.asInstanceOf[PrimitiveStreamAccumulator[Stream[java.lang.Integer], IntAccumulator]]
-  
-  implicit val primitiveUnboxIntStream = new PrimitiveStreamUnboxer[Int, IntStream] {
-    def apply(boxed: Stream[Int]): IntStream = 
-      boxed.mapToInt(new java.util.function.ToIntFunction[Int]{ def applyAsInt(d: Int) = d })
-  }
-  
-  implicit val primitiveUnboxIntStream2 =
-    primitiveUnboxIntStream.asInstanceOf[PrimitiveStreamUnboxer[java.lang.Integer, IntStream]]
-  
-  implicit val primitiveAccumulateLongStream = new PrimitiveStreamAccumulator[Stream[Long], LongAccumulator] { 
-    def streamAccumulate(stream: Stream[Long]): LongAccumulator = 
-      stream.collect(LongAccumulator.supplier, LongAccumulator.boxedAdder, LongAccumulator.merger)
-  }
 
-  implicit val primitiveAccumulateLongStream2 =
+  implicit val primitiveUnboxIntStream: PrimitiveStreamUnboxer[Int, IntStream] =
+    new PrimitiveStreamUnboxer[Int, IntStream] {
+      def apply(boxed: Stream[Int]): IntStream =
+        boxed.mapToInt(new java.util.function.ToIntFunction[Int]{ def applyAsInt(d: Int) = d })
+    }
+
+  implicit val primitiveUnboxIntStream2: PrimitiveStreamUnboxer[java.lang.Integer, IntStream] =
+    primitiveUnboxIntStream.asInstanceOf[PrimitiveStreamUnboxer[java.lang.Integer, IntStream]]
+
+  implicit val primitiveAccumulateLongStream: PrimitiveStreamAccumulator[Stream[Long], LongAccumulator] =
+    new PrimitiveStreamAccumulator[Stream[Long], LongAccumulator] {
+      def streamAccumulate(stream: Stream[Long]): LongAccumulator =
+        stream.collect(LongAccumulator.supplier, LongAccumulator.boxedAdder, LongAccumulator.merger)
+    }
+
+  implicit val primitiveAccumulateLongStream2: PrimitiveStreamAccumulator[Stream[java.lang.Long], LongAccumulator] =
     primitiveAccumulateLongStream.asInstanceOf[PrimitiveStreamAccumulator[Stream[java.lang.Long], LongAccumulator]]
-  
-  implicit val primitiveUnboxLongStream = new PrimitiveStreamUnboxer[Long, LongStream] {
-    def apply(boxed: Stream[Long]): LongStream = 
-      boxed.mapToLong(new java.util.function.ToLongFunction[Long]{ def applyAsLong(d: Long) = d })
-  }
-  
-  implicit val primitiveUnboxLongStream2 =
+
+  implicit val primitiveUnboxLongStream: PrimitiveStreamUnboxer[Long, LongStream] =
+    new PrimitiveStreamUnboxer[Long, LongStream] {
+      def apply(boxed: Stream[Long]): LongStream =
+        boxed.mapToLong(new java.util.function.ToLongFunction[Long]{ def applyAsLong(d: Long) = d })
+    }
+
+  implicit val primitiveUnboxLongStream2: PrimitiveStreamUnboxer[java.lang.Long, LongStream] =
     primitiveUnboxLongStream.asInstanceOf[PrimitiveStreamUnboxer[java.lang.Long, LongStream]]
   
   implicit final class RichDoubleStream(private val stream: DoubleStream) extends AnyVal {
@@ -308,27 +314,30 @@ with converterImpl.Priority1AccumulatorConverters
     }
   }
 
-  implicit val accumulateDoubleStepper = new AccumulatesFromStepper[Double, DoubleAccumulator] {
-    def apply(stepper: Stepper[Double]) = {
-      val a = new DoubleAccumulator
-      while (stepper.hasStep) a += stepper.nextStep
-      a
+  implicit val accumulateDoubleStepper: AccumulatesFromStepper[Double, DoubleAccumulator] =
+    new AccumulatesFromStepper[Double, DoubleAccumulator] {
+      def apply(stepper: Stepper[Double]) = {
+        val a = new DoubleAccumulator
+        while (stepper.hasStep) a += stepper.nextStep
+        a
+      }
     }
-  }
 
-  implicit val accumulateIntStepper = new AccumulatesFromStepper[Int, IntAccumulator] {
-    def apply(stepper: Stepper[Int]) = {
-      val a = new IntAccumulator
-      while (stepper.hasStep) a += stepper.nextStep
-      a
+  implicit val accumulateIntStepper: AccumulatesFromStepper[Int, IntAccumulator] =
+    new AccumulatesFromStepper[Int, IntAccumulator] {
+      def apply(stepper: Stepper[Int]) = {
+        val a = new IntAccumulator
+        while (stepper.hasStep) a += stepper.nextStep
+        a
+      }
     }
-  }
 
-  implicit val accumulateLongStepper = new AccumulatesFromStepper[Long, LongAccumulator] {
-    def apply(stepper: Stepper[Long]) = {
-      val a = new LongAccumulator
-      while (stepper.hasStep) a += stepper.nextStep
-      a
+  implicit val accumulateLongStepper: AccumulatesFromStepper[Long, LongAccumulator] =
+    new AccumulatesFromStepper[Long, LongAccumulator] {
+      def apply(stepper: Stepper[Long]) = {
+        val a = new LongAccumulator
+        while (stepper.hasStep) a += stepper.nextStep
+        a
+      }
     }
-  }
 }

--- a/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala
+++ b/src/main/scala/scala/compat/java8/converterImpl/StepConverters.scala
@@ -5,27 +5,44 @@ import language.implicitConversions
 import scala.reflect.ClassTag
 
 trait Priority3StepConverters {
-  implicit def richIterableCanStep[A](underlying: Iterable[A]) = new RichIterableCanStep(underlying)
-  implicit def richMapCanStep[K, V](underlying: collection.Map[K, V]) = new RichMapCanStep[K, V](underlying)
+  implicit def richIterableCanStep[A](underlying: Iterable[A]): RichIterableCanStep[A] =
+    new RichIterableCanStep(underlying)
+  implicit def richMapCanStep[K, V](underlying: collection.Map[K, V]): RichMapCanStep[K, V] =
+    new RichMapCanStep[K, V](underlying)
 }
 
 trait Priority2StepConverters extends Priority3StepConverters {
-  implicit def richLinearSeqCanStep[A](underlying: collection.LinearSeq[A]) = new RichLinearSeqCanStep[A](underlying)
-  implicit def richIndexedSeqCanStep[A](underlying: collection.IndexedSeqOps[A, Any, _]) = new RichIndexedSeqCanStep[A](underlying)
+  implicit def richLinearSeqCanStep[A](underlying: collection.LinearSeq[A]): RichLinearSeqCanStep[A] =
+    new RichLinearSeqCanStep[A](underlying)
+  implicit def richIndexedSeqCanStep[A](underlying: collection.IndexedSeqOps[A, Any, _]): RichIndexedSeqCanStep[A] =
+    new RichIndexedSeqCanStep[A](underlying)
 }
 
 trait Priority1StepConverters extends Priority2StepConverters {
-  implicit def richDefaultHashMapCanStep[K, V](underlying: collection.mutable.HashMap[K, V]) = new RichHashMapCanStep[K, V](underlying)
-  implicit def richLinkedHashMapCanStep[K, V](underlying: collection.mutable.LinkedHashMap[K, V]) = new RichLinkedHashMapCanStep[K, V](underlying)
-  implicit def richArrayCanStep[A](underlying: Array[A]) = new RichArrayCanStep[A](underlying)
-  implicit def richArraySeqCanStep[A: ClassTag](underlying: collection.mutable.ArraySeq[A]) = new RichArrayCanStep[A](StreamConverters.unsafeArrayIfPossible(underlying))
-  implicit def richHashSetCanStep[A](underlying: collection.mutable.HashSet[A]) = new RichHashSetCanStep[A](underlying)
-  implicit def richIteratorCanStep[A](underlying: Iterator[A]) = new RichIteratorCanStep(underlying)
-  implicit def richImmHashMapCanStep[K, V](underlying: collection.immutable.HashMap[K, V]) = new RichImmHashMapCanStep[K, V](underlying)
-  implicit def richImmHashSetCanStep[A](underlying: collection.immutable.HashSet[A]) = new RichImmHashSetCanStep[A](underlying)
-  implicit def richNumericRangeCanStep[T](underlying: collection.immutable.NumericRange[T]) = new RichNumericRangeCanStep(underlying)
-  implicit def richVectorCanStep[A](underlying: Vector[A]) = new RichVectorCanStep[A](underlying)
-  implicit def richBitSetCanStep(underlying: collection.BitSet) = new RichBitSetCanStep(underlying)
-  implicit def richRangeCanStep(underlying: Range) = new RichRangeCanStep(underlying)
-  implicit def richStringCanStep(underlying: String) = new RichStringCanStep(underlying)
+  implicit def richDefaultHashMapCanStep[K, V](underlying: collection.mutable.HashMap[K, V]): RichHashMapCanStep[K, V] =
+    new RichHashMapCanStep[K, V](underlying)
+  implicit def richLinkedHashMapCanStep[K, V](underlying: collection.mutable.LinkedHashMap[K, V]): RichLinkedHashMapCanStep[K, V] =
+    new RichLinkedHashMapCanStep[K, V](underlying)
+  implicit def richArrayCanStep[A](underlying: Array[A]): RichArrayCanStep[A] =
+    new RichArrayCanStep[A](underlying)
+  implicit def richArraySeqCanStep[A: ClassTag](underlying: collection.mutable.ArraySeq[A]): RichArrayCanStep[A] =
+    new RichArrayCanStep[A](StreamConverters.unsafeArrayIfPossible(underlying))
+  implicit def richHashSetCanStep[A](underlying: collection.mutable.HashSet[A]): RichHashSetCanStep[A] =
+    new RichHashSetCanStep[A](underlying)
+  implicit def richIteratorCanStep[A](underlying: Iterator[A]): RichIteratorCanStep[A] =
+    new RichIteratorCanStep(underlying)
+  implicit def richImmHashMapCanStep[K, V](underlying: collection.immutable.HashMap[K, V]): RichImmHashMapCanStep[K, V] =
+    new RichImmHashMapCanStep[K, V](underlying)
+  implicit def richImmHashSetCanStep[A](underlying: collection.immutable.HashSet[A]): RichImmHashSetCanStep[A] =
+    new RichImmHashSetCanStep[A](underlying)
+  implicit def richNumericRangeCanStep[T](underlying: collection.immutable.NumericRange[T]): RichNumericRangeCanStep[T] =
+    new RichNumericRangeCanStep(underlying)
+  implicit def richVectorCanStep[A](underlying: Vector[A]): RichVectorCanStep[A] =
+    new RichVectorCanStep[A](underlying)
+  implicit def richBitSetCanStep(underlying: collection.BitSet): RichBitSetCanStep =
+    new RichBitSetCanStep(underlying)
+  implicit def richRangeCanStep(underlying: Range): RichRangeCanStep[Int] =
+    new RichRangeCanStep(underlying)
+  implicit def richStringCanStep(underlying: String): RichStringCanStep =
+    new RichStringCanStep(underlying)
 }


### PR DESCRIPTION
~~three sorts of changes here:~~
* adding explicit result types to implicits.  not sure what Scala
  change made these fail to compile otherwise, but they are good
  changes regardless
~~* changing `.array` to `.toArray` when we are dealing with
  `ArraySeq`, because scala/scala#6837~~
~~* adding `: ClassTag` in one place, also because scala/scala#6837.
  this change is not binary compatible and isn't fully source
  compatible either, but it's okay, this is a 2.13-only branch.~~
