### PR TITLE
ignore JDK 12 only warnings when compiling build definition

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,8 @@
-scalacOptions += "-Xfatal-warnings"
+scalacOptions ++= (sys.props("java.specification.version") match {
+  // work around weird dbuild thing for JDK 12 community build; see
+  // https://github.com/scala/community-builds/issues/862#issuecomment-464227096
+  case "12" => Seq()
+  case _ => Seq("-Xfatal-warnings")
+})
 
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")


### PR DESCRIPTION
context: https://github.com/scala/community-builds/issues/862