### PR TITLE
update Travis-CI setup: use OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: scala
 
-sudo: false
-
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 scala:
-  # no 2.13 for now in cross-build because of
-  # https://github.com/scala/scala-java8-compat/issues/97
+  # note that 2.13 is on the 2.13.x branch instead
   - 2.11.12
   - 2.12.8
 


### PR DESCRIPTION
we are standardizing on this for all the modules, most were
changed already, this one was not