### PR TITLE
genjavadoc 0.19 (was 0.18) — except for Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,7 @@ lazy val scalaJava8Compat = (project in file("."))
         JavaDoc / packageDoc / artifactName := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"),
         libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((3, _)) => Seq()
-          case _            => Seq(compilerPlugin("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.18" cross CrossVersion.full))
+          case _            => Seq(compilerPlugin("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.19" cross CrossVersion.full))
         }),
         Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((3, _)) => Seq()

--- a/build.sbt
+++ b/build.sbt
@@ -130,8 +130,9 @@ lazy val scalaJava8Compat = (project in file("."))
         JavaDoc / javacOptions := Seq("-Xdoclint:none"),
         JavaDoc / packageDoc / artifactName := ((sv, mod, art) => "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"),
         libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((3, _)) => Seq()
-          case _            => Seq(compilerPlugin("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.19" cross CrossVersion.full))
+          case Some((3, _))  => Seq()
+          case Some((2, 11)) => Seq(compilerPlugin("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.18" cross CrossVersion.full))
+          case _             => Seq(compilerPlugin("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.19" cross CrossVersion.full))
         }),
         Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((3, _)) => Seq()


### PR DESCRIPTION
0.18 was the final version for 2.11, but for 2.13.14, we need 0.19